### PR TITLE
Fixes to make pypi happy

### DIFF
--- a/runperf/__init__.py
+++ b/runperf/__init__.py
@@ -34,8 +34,9 @@ from .machine import Controller
 
 
 PROG = 'run-perf'
-DESCRIPTION = ("Tool to execute perf tests under given profiles using "
-               "beaker, libvirt and other useful tools.")
+DESCRIPTION = ("A tool to execute the same tasks on pre-defined scenarios/"
+               "profiles and store the results together with metadata in "
+               "a suitable structure for compare-perf to compare them.")
 
 
 def get_abs_path(path):

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,10 @@ def get_version():
     return version
 
 
-VERSION = get_version()
+if os.environ.get('RUNPERF_RELEASE'):
+    VERSION = 0.9
+else:
+    VERSION = get_version()
 
 
 def get_long_description():


### PR DESCRIPTION
Pypi requires version to conform to PEP440, let's add a "release" version and tag those on github. Also I noticed that the run-perf description is not really reflecting the current implementation so fixed that.