### PR TITLE
tests: Set benchmark_bin on pbench tests

### DIFF
--- a/runperf/tests.py
+++ b/runperf/tests.py
@@ -125,7 +125,13 @@ class PBenchTest(BaseTest):
                 time.sleep(5)
                 session.cmd("true")
                 # And now run the test
-                session.cmd_output(self._cmd,
+                benchmark_bin = session.cmd_output("which %s"
+                                                   % self.test).strip()
+                if benchmark_bin:
+                    prefix = "benchmark_bin=%s " % benchmark_bin
+                else:
+                    prefix = ""
+                session.cmd_output(prefix + self._cmd,
                                    timeout=self.timeout)
                 # Let the system to rest a bit after heavy load
                 time.sleep(5)


### PR DESCRIPTION
Epel uses /usr/bin/$tool location by default, which sometimes does not
correspond with the default pbench location. Let's try to find the tool
via `which` command and pass it to the execution if found.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>