### PR TITLE
Fix libvirt get_session() failures

### DIFF
--- a/runperf/machine.py
+++ b/runperf/machine.py
@@ -698,8 +698,9 @@ class LibvirtGuest(BaseMachine):
 
     def get_info(self):
         out = BaseMachine.get_info(self)
-        out["libvirt_xml"] = self.get_host_session().cmd_output(
-            "virsh dumpxml '%s'" % self.name)
+        out["libvirt_xml"] = self.get_host_session().cmd(
+            "virsh dumpxml '%s'" % self.name, print_func="mute",
+            ignore_all_errors=True)
         return out
 
     def start(self):

--- a/runperf/machine.py
+++ b/runperf/machine.py
@@ -665,6 +665,11 @@ class LibvirtGuest(BaseMachine):
         self.xml = None
         self.image = None
 
+    def get_session(self, timeout=60, hop=None):
+        if hop is None:
+            hop = self.host
+        return BaseMachine.get_session(self, timeout=timeout, hop=hop)
+
     def get_host_session(self):
         """
         Get and cache host session.

--- a/runperf/tests.py
+++ b/runperf/tests.py
@@ -152,11 +152,11 @@ class PBenchTest(BaseTest):
             pbench.install_on(session, self.metadata, test=self.test)
         for workers in self.workers:
             for worker in workers:
-                with worker.get_session_cont(hop=self.host) as session:
+                with worker.get_session_cont() as session:
                     pbench.install_on(session, self.metadata, test=self.test)
         for workers in self.workers:
             for worker in workers:
-                with worker.get_session_cont(hop=self.host) as session:
+                with worker.get_session_cont() as session:
                     if not utils.wait_for_machine_calms_down(session,
                                                              timeout=1800):
                         worker.log.warning("Worker did not stabilize in 1800s,"


### PR DESCRIPTION
Recently added worker.get_session() without additional `hop=host` causes failures. Instead of adding the hop let's just modify the default libvirt machine `get_session` to inject the hop (as we pretty well know it's needed) while allowing the user to override it.

While on it removed some unwanted logs.