### PR TITLE
utils: Use 1m load for wait_for_machine_calms_down

### DIFF
--- a/runperf/utils/__init__.py
+++ b/runperf/utils/__init__.py
@@ -322,7 +322,7 @@ def shell_write_content_cmd(path, content, append=False):
 
 def wait_for_machine_calms_down(session, timeout=600):
     """
-    Wait until 5m system load calms below 1.0
+    Wait until 1m system load calms below 1.0
 
     :param session: session
     :param timeout: timeout
@@ -332,7 +332,7 @@ def wait_for_machine_calms_down(session, timeout=600):
     try:
         if not session.cmd_status('( END="$(expr $(date \'+%%s\') + %s)"; '
                                   'while [ "$(date \'+%%s\')" -lt "$END" ]; '
-                                  'do [ "$(cat /proc/loadavg | cut -d\' \' -f2'
+                                  'do [ "$(cat /proc/loadavg | cut -d\' \' -f1'
                                   ' | cut -d\'.\' -f1)" -eq 0 ] && exit 0; '
                                   'sleep 5; done; exit 1 )' % timeout,
                                   timeout=timeout + 11):


### PR DESCRIPTION
The loadavg is a moving average and calming down from load about 20 to 0
can take tenths of minuts while we are looking more for something in a
matter of minutes. Let's use the 1m load where calming down from load 40
to 0 takes about 4m, which should be plenty of time for the machine to
calm down.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>