### PR TITLE
tests: Fix PBench "types" argument

### DIFF
--- a/docs/source/jenkins/jobs.yml
+++ b/docs/source/jenkins/jobs.yml
@@ -16,7 +16,7 @@
     param-distro: ''
     param-guest-distro: ''
     # By default we use those 3 tests (the quotation is required)
-    param-tests: "'fio:{{\"targets\": \"/fio\"}}' 'uperf:{{\"protocols\": \"tcp\"}}' 'uperf:{{\"protocols\": \"udp\", \"type\": \"rr\"}}'"
+    param-tests: "'fio:{{\"targets\": \"/fio\"}}' 'uperf:{{\"protocols\": \"tcp\"}}' 'uperf:{{\"protocols\": \"udp\", \"test-types\": \"rr\"}}'"
     # By default we use these profiles
     param-profiles: "Localhost DefaultLibvirt TunedLibvirt"
     # Set the default tolerances

--- a/runperf/tests.py
+++ b/runperf/tests.py
@@ -248,7 +248,7 @@ class PBenchFio(PBenchTest):
 
     name = "fio"
     test = "fio"
-    default_args = (("type", "read,write,rw"),
+    default_args = (("test-types", "read,write,rw"),
                     ("ramptime", 10),
                     ("runtime", 180),
                     ("samples", 3))
@@ -301,7 +301,7 @@ class UPerf(PBenchTest):
 
     name = "uperf"
     test = "uperf"
-    default_args = (("type", "stream"),
+    default_args = (("test-types", "stream"),
                     ("runtime", 60),
                     ("samples", 3),
                     ("protocols", "tcp"),


### PR DESCRIPTION
The pbench-* command to modify test types is "--test-types" so we need
to change the argument used for this handling as previously we
simplified it to only "types" which does not matches the current setup
as "extra" options can directly set any "--$arg" option directly.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>