### PR TITLE
Rework the pbench-test extra params handling and add fio-nbd test

### DIFF
--- a/docs/source/scripts.rst
+++ b/docs/source/scripts.rst
@@ -76,6 +76,8 @@ Test runners are implemented under :mod:`runperf.tests` and currently consists
 of two `pbench-based <https://distributed-system-analysis.github.io/pbench/pbench-agent.html>`_
 tests:
 
+.. _test-fio:
+
 Fio
 ---
 
@@ -88,6 +90,15 @@ IO intense test. You can tweak following params:
 * samples - number of samples to use per test iteration [3]
 * file-size - file sizes in MiB (must be bigger than the biggest block size)
 * targets - one or more directories or block devices
+
+Fio-nbd
+-------
+
+This is a special case of :ref:`test-fio` test but it is spawning qemu-nbd
+export on each worker and tests the speed of the exported device. You can
+still tweak various params (like type, ...) but note that the ``targets``,
+``numjobs`` and ``job-file`` should be set automatically to suit the
+configuration.
 
 Uperf
 -----

--- a/runperf/machine.py
+++ b/runperf/machine.py
@@ -451,6 +451,8 @@ class Controller:
         except Exception as exc:
             self.log.error("  FAILURE test %s: %s" % (name, exc))
             raise
+        finally:
+            test.cleanup()
 
     def cleanup(self):
         """Post-testing cleanup"""

--- a/runperf/tests.py
+++ b/runperf/tests.py
@@ -122,6 +122,11 @@ class BaseTest:
                                                           results_json),
                             timeout=600, print_func='mute')
 
+    def cleanup(self):
+        """
+        Cleanup the environment; is **always** executed even for SKIP tests
+        """
+
 
 class PBenchTest(BaseTest):
     """

--- a/runperf/tests.py
+++ b/runperf/tests.py
@@ -330,6 +330,69 @@ class UPerf(PBenchTest):
         self._cmd += (" --servers %s" % (",".join(addrs)))
 
 
+class PBenchNBD(PBenchFio):
+    """
+    Executes PBenchFio with a custom job to test nbd
+
+    By default it creates and distributes the job-file using "nbd-check.fio"
+    from assets but you can override the job-file path and distribute your
+    own version. In such case you have to make sure to use the right paths
+    and format.
+    """
+    name = "fio-nbd"
+    default_args = (("numjobs", 4),
+                    ("job-file", "/tmp/runperf-nbd/nbd.fio"))
+
+    def __init__(self, host, workers, base_output_path, metadata, extra):
+        self.fio_job_file = extra.get("job-file", "/tmp/runperf-nbd/nbd.fio")
+        PBenchFio.__init__(self, host, workers, base_output_path, metadata,
+                           extra)
+
+    def setup(self):
+        PBenchFio.setup(self)
+        with open(os.path.join(os.path.dirname(__file__), "assets", "pbench",
+                               "nbd-check.fio")) as fio_check:
+            fio_check_tpl = utils.shell_write_content_cmd("/tmp/runperf-"
+                                                          "nbd/nbd-check.fio",
+                                                          fio_check.read())
+        with open(os.path.join(os.path.dirname(__file__), "assets", "pbench",
+                               "nbd.fio")) as fio:
+            fio_tpl = utils.shell_write_content_cmd(self.fio_job_file,
+                                                    fio.read())
+        for workers in self.workers:
+            for worker in workers:
+                with worker.get_session_cont() as session:
+                    session.cmd("mkdir -p /tmp/runperf-nbd")
+                    session.cmd(fio_check_tpl)
+                    ret = session.cmd_status("fio --parse-only /tmp/runperf-"
+                                             "nbd/nbd-check.fio")
+                    if ret:
+                        raise exceptions.TestSkip("Fio %s does not support "
+                                                  "ioengine=nbd on worker %s"
+                                                  % (session.cmd("which fio"),
+                                                     worker))
+                    session.cmd("truncate -s 256M /tmp/runperf-nbd/disk.img")
+                    session.cmd("nohup qemu-nbd -t -k /tmp/runperf-nbd/socket"
+                                " -f raw /tmp/runperf-nbd/disk.img &> "
+                                "$(mktemp /tmp/runperf-nbd/qemu_nbd_XXXX.log)"
+                                " & echo $! >> /tmp/runperf-nbd/kill_pids")
+        with self.host.get_session_cont(hop=self.host) as session:
+            session.cmd("mkdir -p /tmp/runperf-nbd")
+            session.cmd(fio_tpl)
+
+    def cleanup(self):
+        for workers in self.workers:
+            for worker in workers:
+                with worker.get_session_cont() as session:
+                    pids = session.cmd("cat /tmp/runperf-nbd/kill_pids "
+                                       "2>/dev/null || true")
+                    for pid in pids.splitlines():
+                        session.cmd_status("kill -9 '%s'" % pid)
+                    session.cmd("rm -Rf /tmp/runperf-nbd")
+        with self.host.get_session_cont(hop=self.host) as session:
+            session.cmd("rm -Rf /tmp/runperf-nbd")
+        PBenchFio.cleanup(self)
+
 def get(name):
     """
     Get list of test classes based on test name

--- a/runperf/utils/pbench.py
+++ b/runperf/utils/pbench.py
@@ -97,7 +97,7 @@ class Dnf:  # pylint: disable=R0903
                     "pbench-sysstat", timeout=600)
         self._update_pbench()
 
-    def _check_test_installed(self, test):
+    def _check_test_installed(self):
         """Report whether test pkg is installed"""
         if not self.session.cmd_status("rpm -q %s" % self.test):
             return True
@@ -109,13 +109,12 @@ class Dnf:  # pylint: disable=R0903
         """Install pbench-$test package"""
         if not self.test:
             return ""
-        # TODO: Report discovered version
-        if self._check_test_installed(self.test):
+        if self._check_test_installed():
             return ""
         if self.session.cmd_status("dnf install -y --skip-broken --nobest %s "
                                    "pbench-%s" % (self.test, self.test)):
             return "Failed to install %s" % self.test
-        if self._check_test_installed(test):
+        if self._check_test_installed():
             return ""
         return "Faled to install %s" % self.test
 

--- a/runperf/utils/pbench.py
+++ b/runperf/utils/pbench.py
@@ -99,6 +99,8 @@ class Dnf:  # pylint: disable=R0903
 
     def _check_test_installed(self):
         """Report whether test pkg is installed"""
+        if not self.session.cmd_status("which %s" % self.test):
+            return True
         if not self.session.cmd_status("rpm -q %s" % self.test):
             return True
         if not self.session.cmd_status("rpm -q pbench-%s" % self.test):

--- a/setup.py
+++ b/setup.py
@@ -79,7 +79,8 @@ if __name__ == '__main__':
               'runperf.tests': [
                   'PBenchFio = runperf.tests:PBenchFio',
                   'Linpack = runperf.tests:Linpack',
-                  'UPerf = runperf.tests:UPerf'],
+                  'UPerf = runperf.tests:UPerf',
+                  'PBenchNBD = runperf.tests:PBenchNBD'],
               'runperf.machine.distro_info': [
                   'get_distro_info = runperf.machine:get_distro_info'],
               'runperf.utils.cloud_image_providers': [


### PR DESCRIPTION
The pbench extra params handling had been added per-test using a white-list of handled args, let's simply assume that all `extra` params are `--$param` while allowing `default_args` to be specified per test.

On top of this change let's add a `fio-nbd` test which is a special case of the `PbenchFio` test. It creates a qemu-nbd export per each worker and uses `fio` to test the exported device.