### PR TITLE
docs: Add documentation about "hosts"

### DIFF
--- a/docs/source/downstream.rst
+++ b/docs/source/downstream.rst
@@ -4,6 +4,8 @@
 Downstream extensions
 =====================
 
+.. _downstream-assets:
+
 Assets
 ------
 

--- a/docs/source/scripts.rst
+++ b/docs/source/scripts.rst
@@ -36,6 +36,32 @@ it runs all tests under all profiles.
 
 Now let's focus on the available elements:
 
+Hosts
+=====
+
+Hosts are the machines to be utilized in testing. Each test can request
+one or multiple machines and it is up to the user to provide sufficient
+number of hosts.
+
+Run-perf needs to know certain metadata about each host. You can either
+store them in your :ref:`downstream-extensions` via :ref:`downstream-assets`
+or you can provide them via ``--force-params`` cmdline argument.
+
+Currently the minimum set of params is:
+
+* ``hugepage_kb`` - which hugepage size to use
+* ``numa_nodes`` - number of host's numa nodes
+* ``host_cpus`` - how many cpus there are on the host
+* ``guest_cpus`` - how many cpus we should use for workers
+* ``guest_mem_m`` - how much memory we can use for workers. Leaving enough
+  free space for the system is important especially when using hugepages
+  as otherwise it might fail to obtain enough continuous memory for them.
+* ``arch`` - host's architecture
+
+There are some optional arguments like:
+
+* ``disable_smt`` - whether to disable smt on the host before testing
+
 Profiles
 ========
 


### PR DESCRIPTION
Runperf requires certain metadata about the used hosts, which might not
be obvious. Let's include a small section explaining what we require and
how to set it.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>