### PR TITLE
tests: Fix linpack setup

### DIFF
--- a/runperf/__init__.py
+++ b/runperf/__init__.py
@@ -411,6 +411,7 @@ class AnalyzePerf:
         result_names = set()
         for path in args.results:
             results_name = os.path.basename(path)
+            result_names.add(results_name)
             for test, score, _, _ in result.iter_results(path, True):
                 if test not in storage:
                     storage[test] = {}
@@ -427,6 +428,8 @@ class AnalyzePerf:
                 csv.write("test,%s" % ",".join(csv_safe_str(_)
                                                for _ in result_names))
                 for test in sorted(storage.keys()):
+                    if "Gb_sec.mean" not in test:
+                        continue
                     test_results = storage.get(test, {})
                     csv.write("\n%s," % test)
                     for result_name in result_names:


### PR DESCRIPTION
Previously we tried detecting linpack binary before we installed it.
Let's move the detection to the `_run` phase where the `setup()` (and
therefor pbench-fio install) should have already been called.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>