### PR TITLE
Use git describe-based versioning scheme

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -15,7 +15,7 @@ import subprocess
 import sys
 ROOT_PATH = os.path.abspath(os.path.join(os.path.pardir, os.path.pardir))
 sys.path.insert(0, ROOT_PATH)
-from setup import get_version  # pylint: disable=C0413
+from setup import _get_git_version  # pylint: disable=C0413
 
 # -- Project information -----------------------------------------------------
 
@@ -24,7 +24,7 @@ copyright = '2020, Lukáš Doktor'
 author = 'Lukáš Doktor'
 
 # The full version, including alpha/beta/rc tags
-release = get_version()
+release = _get_git_version()
 
 # -- API docs ----------------------------------------------------------------
 API_SOURCE_DIR = os.path.join(ROOT_PATH, 'runperf')

--- a/runperf/__init__.py
+++ b/runperf/__init__.py
@@ -27,10 +27,10 @@ import threading
 import time
 
 import aexpect
-import pkg_resources
 
 from . import exceptions, tests, result
 from .machine import Controller
+from .version import __version__
 
 PROG = 'run-perf'
 DESCRIPTION = ("A tool to execute the same tasks on pre-defined scenarios/"
@@ -180,7 +180,7 @@ def create_metadata(output_dir, args):
         else:
             output.write("guest_distro:%s\n" % args.guest_distro)
         output.write("runperf_version:%s\n"
-                     % pkg_resources.get_distribution("runperf").version)
+                     % __version__)
         cmd = list(sys.argv)
         for i in range(len(cmd)):  # pylint: disable=C0200
             this = cmd[i]

--- a/runperf/assets/html_report/report_template.html
+++ b/runperf/assets/html_report/report_template.html
@@ -10460,7 +10460,7 @@ a {font-family: monospace;}
     </tr>
     <tr>
         <td>Runperf version</td>{% for build in builds %}
-        <td style='{{ relative_score_color(build) }}'><a href="https://github.com/distributed-system-analysis/run-perf/commit/{{build.runperf_version}}">{{build.runperf_version[:6]}}</a></td>{% endfor %}
+        <td style='{{ relative_score_color(build) }}'><a href="https://github.com/distributed-system-analysis/run-perf/tree/{{build.runperf_version}}">{{build.runperf_version[:6]}}</a></td>{% endfor %}
     </tr>
     <tr>
         <td>Runperf cmd</td>{% for build in builds %}

--- a/runperf/html_report.py
+++ b/runperf/html_report.py
@@ -144,8 +144,12 @@ def generate_report(path, results, with_charts=False):
             for key in ["build", "machine", "machine_url", "url", "distro",
                         "runperf_cmd"]:
                 build[key] = metadata[key]
-            if "runperf_version" in metadata:
-                build["runperf_version"] = metadata["runperf_version"][:6]
+            version = metadata.get('runperf_version', None)
+            if version:
+                if version.count('-') > 1:
+                    # turn "0.9-96-g04b4b9f-dirty" into "04b4b9f-dirty"
+                    version = version.split('-', 2)[2][1:]
+                build["runperf_version"] = version
             else:
                 build["runperf_version"] = metadata.default_factory()
             build["guest_distro"] = metadata.get("guest_distro",

--- a/runperf/version.py
+++ b/runperf/version.py
@@ -1,0 +1,62 @@
+#!/bin/env python3
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: Red Hat Inc. 2020
+# Author: Lukas Doktor <ldoktor@redhat.com>
+
+"""
+The purpose of this implementation is to return the right version for
+installed as well as 'make develop' deployments.
+"""
+
+
+import os
+import subprocess
+
+import pkg_resources
+
+
+# Path to setup.py. It only exists when used from sources
+SETUP_PATH = os.path.dirname(os.path.dirname(__file__))
+
+def _get_git_version():
+    """
+    Get version from git describe
+
+    :warning: This implementation must match the "../setup.py" one
+    """
+    curdir = os.getcwd()
+    try:
+        os.chdir(SETUP_PATH)
+        version = subprocess.check_output(
+            ["git", "describe", "--tags", "HEAD"]).strip().decode("utf-8")
+        try:
+            subprocess.check_output(["git", "diff", "--quiet"])
+        except subprocess.CalledProcessError:
+            version += "-dirty"
+    except Exception:
+        return None
+    finally:
+        os.chdir(curdir)
+    return version
+
+def get_version():
+    """
+    Attempt to get the version from git or fallback to pkg_resources
+    """
+    if os.path.exists(os.path.join(SETUP_PATH, '.git')):
+        version = _get_git_version()
+        if version:
+            return version
+    return pkg_resources.get_distribution("runperf").version
+
+__version__ = get_version()

--- a/setup.py
+++ b/setup.py
@@ -19,37 +19,40 @@ import subprocess
 
 from setuptools import setup, find_packages
 
-BASE_PATH = os.path.dirname(__file__)
+SETUP_PATH = os.path.abspath(os.path.dirname(__file__))
 
 
-def get_version():
+def _get_git_version():
+    """
+    Get version from git describe
+
+    :warning: This implementation must match the "runperf/version.py" one
+    """
+    curdir = os.getcwd()
     try:
-        version = (subprocess.check_output(["git", "rev-parse", "HEAD"])
-                   .strip().decode("utf-8"))
+        os.chdir(SETUP_PATH)
+        version = subprocess.check_output(
+            ["git", "describe", "--tags", "HEAD"]).strip().decode("utf-8")
         try:
             subprocess.check_output(["git", "diff", "--quiet"])
-        except Exception:
+        except subprocess.CalledProcessError:
             version += "-dirty"
     except Exception:
-        return "Unknown2"
+        return None
+    finally:
+        os.chdir(curdir)
     return version
 
 
-if os.environ.get('RUNPERF_RELEASE'):
-    VERSION = 0.9
-else:
-    VERSION = get_version()
-
-
 def get_long_description():
-    with open(os.path.join(BASE_PATH, 'README.rst'), 'r') as req:
+    with open(os.path.join(SETUP_PATH, 'README.rst'), 'r') as req:
         req_contents = req.read()
     return req_contents
 
 
 if __name__ == '__main__':
     setup(name='runperf',
-          version=VERSION,
+          version=_get_git_version(),
           description='Helper to execute perf-beaker-tasks locally or in VM',
           long_description=get_long_description(),
           author='Lukas Doktor',


### PR DESCRIPTION
Use "git describe" to either get the current tag or the closest tag with
hash. On top of that also check for dirtiness and append the "-dirty" in
such case.

As a result we should get versions like:

    0.9
    0.9-dirty
    0.9-95-g5c6fd51-dirty

which should conform with the usual python versioning while allowing
to parse the actual commit/tag from the output.

Fixes: #15