### PR TITLE
profiles: Allocate HPs during boot in TunedLibvirt

### DIFF
--- a/runperf/profiles.py
+++ b/runperf/profiles.py
@@ -422,7 +422,10 @@ class TunedLibvirt(DefaultLibvirt):
 
         # GRUBBY
         cmdline = self._read_file("/proc/cmdline")
-        args = ["default_hugepagesz=1G", "nosoftlockup", "nohz=on"]
+        total_hp = int(self.host.params["guest_mem_m"] * 1024 /
+                       self.host.params["hugepage_kb"])
+        args = ["default_hugepagesz=1G", "hugepagesz=1G", "nosoftlockup",
+                "nohz=on", "hugepages=%s" % total_hp]
         args = " ".join(arg for arg in args if arg not in cmdline)
         self._set("profile/TunedLibvirt/kernel_cmdline", args)
         self.session.cmd('grubby --args="%s" '


### PR DESCRIPTION
Sometimes even on boot we fail to allocate enough HPs, let's add
hugepages to the kernel boot cmdline, which should be distributed
equally across all nodes.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>