### PR TITLE
html_report: Avoid crash when src contains dict

### DIFF
--- a/runperf/html_report.py
+++ b/runperf/html_report.py
@@ -88,7 +88,7 @@ def generate_report(path, results, with_charts=False):
                     # Skip raw values comparison
                     continue
                 if key in src:
-                    # Store only diff lines starting wiht +- as
+                    # Store only diff lines starting with +- as
                     # we don't need a "useful" diff but just an
                     # overview of what is different.
                     raw_diff = unified_diff(

--- a/runperf/html_report.py
+++ b/runperf/html_report.py
@@ -92,7 +92,7 @@ def generate_report(path, results, with_charts=False):
                     # we don't need a "useful" diff but just an
                     # overview of what is different.
                     raw_diff = unified_diff(
-                        src[key].splitlines(),
+                        str(src[key]).splitlines(),
                         value.splitlines())
                     # Skip first two lines as it contains +++ and ---
                     try:


### PR DESCRIPTION
In case some plugin stores dict in dict of env we can end-up in
comparing dict, let's always convert to string before the splitlines as
a hotfix.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>