### PR TITLE
Support for plugin ordering

### DIFF
--- a/docs/source/downstream.rst
+++ b/docs/source/downstream.rst
@@ -31,4 +31,7 @@ Available ones are:
 * runperf.utils.pbench - to add custom pbench setup
 * runperf.machine.distro_info - to extend machine sysinfo collection
 
-the order depends on which entry point was installed first.
+The plugins are checked in the alphabetical order based on the entry
+point name. Default entry points are prefixed leaving enough space
+to prefix more or less important downstream plugins with lower or
+higher values.

--- a/runperf/provisioners.py
+++ b/runperf/provisioners.py
@@ -25,6 +25,7 @@ class Beaker:
 
     Uses current machine to execute "bkr" client
     """
+    name = "Beaker"
 
     def __init__(self, controller, extra):
         """

--- a/runperf/tests.py
+++ b/runperf/tests.py
@@ -20,8 +20,6 @@ import sys
 import tempfile
 import time
 
-import pkg_resources
-
 from . import exceptions
 from . import utils
 from .utils import pbench
@@ -86,7 +84,7 @@ class BaseTest:
             meta[key] = value
         meta['cmdline'] = str(sys.argv)
         meta['distro'] = self.host.distro
-        meta['profile'] = self.host.profile.profile
+        meta['profile'] = self.host.profile.name
         str_workers = {}
         for i, workers in enumerate(self.workers):
             str_workers[i] = {worker.name: worker.get_info()
@@ -244,7 +242,7 @@ class PBenchTest(BaseTest):
                                 % " ".join(extra_args), timeout=600)
                 self.add_metadata(session, "cmdline", str(sys.argv))
                 self.add_metadata(session, "profile",
-                                  self.host.profile.profile)
+                                  self.host.profile.name)
                 self.add_metadata(session, "distro", self.host.distro)
                 for workers in self.workers:
                     for worker in workers:
@@ -426,8 +424,4 @@ def get(name):
         extra = json.loads(_name[1])
     else:
         extra = {}
-    for entry in pkg_resources.iter_entry_points('runperf.tests'):
-        plugin = entry.load()
-        if plugin.name == name:
-            return (plugin, extra)
-    raise RuntimeError("No provider for %s" % name)
+    return (utils.named_entry_point('runperf.tests', name), extra)

--- a/runperf/utils/pbench.py
+++ b/runperf/utils/pbench.py
@@ -14,10 +14,9 @@
 # Author: Lukas Doktor <ldoktor@redhat.com>
 import os
 
-from pkg_resources import iter_entry_points as pkg_entry_points
-
 from . import shell_write_content_cmd
 import collections
+from runperf.utils import sorted_entry_points
 
 
 class Dnf:  # pylint: disable=R0903
@@ -126,7 +125,7 @@ def install_on(session, extra=None, test=None):
     Try available providers to install pbench
     """
     errs = []
-    for entry in pkg_entry_points('runperf.utils.pbench'):
+    for entry in sorted_entry_points('runperf.utils.pbench'):
         plugin = entry.load()(session, extra, test)
         try:
             out = plugin.install()

--- a/selftests/core/test_tests.py
+++ b/selftests/core/test_tests.py
@@ -57,7 +57,8 @@ class PBenchTest(Selftest):
                          ["", "prefix+self._cmd", "0", result_path,
                           result_json])}
         host.mock_session = mock.Mock(**mock_args)
-        host.profile = mock.Mock(profile=profile)
+        host.profile = mock.Mock()
+        host.profile.name = profile
         worker = DummyHost(logging.getLogger(''), 'Test2', 'addr2',
                            guest_distro or distro, args)
         worker.mock_session = mock.Mock(

--- a/setup.py
+++ b/setup.py
@@ -78,24 +78,24 @@ if __name__ == '__main__':
                    'scripts/compare-perf'],
           entry_points={
               'runperf.profiles': [
-                  'Localhost = runperf.profiles:Localhost',
-                  'DefaultLibvirt = runperf.profiles:DefaultLibvirt',
-                  'Overcommit1_5 = runperf.profiles:Overcommit1p5',
-                  'TunedLibvirt = runperf.profiles:TunedLibvirt'],
+                  '50Localhost = runperf.profiles:Localhost',
+                  '50DefaultLibvirt = runperf.profiles:DefaultLibvirt',
+                  '50Overcommit1_5 = runperf.profiles:Overcommit1p5',
+                  '50TunedLibvirt = runperf.profiles:TunedLibvirt'],
               'runperf.tests': [
-                  'DummyTest = runperf.tests:DummyTest',
-                  'PBenchFio = runperf.tests:PBenchFio',
-                  'Linpack = runperf.tests:Linpack',
-                  'UPerf = runperf.tests:UPerf',
-                  'PBenchNBD = runperf.tests:PBenchNBD'],
+                  '50DummyTest = runperf.tests:DummyTest',
+                  '50PBenchFio = runperf.tests:PBenchFio',
+                  '50Linpack = runperf.tests:Linpack',
+                  '50UPerf = runperf.tests:UPerf',
+                  '50PBenchNBD = runperf.tests:PBenchNBD'],
               'runperf.machine.distro_info': [
-                  'get_distro_info = runperf.machine:get_distro_info'],
+                  '50get_distro_info = runperf.machine:get_distro_info'],
               'runperf.utils.cloud_image_providers': [
-                  'Fedora = runperf.utils.cloud_image_providers:Fedora'],
+                  '50Fedora = runperf.utils.cloud_image_providers:Fedora'],
               'runperf.provisioners': [
-                  'Beaker = runperf.provisioners:Beaker'],
+                  '50Beaker = runperf.provisioners:Beaker'],
               'runperf.utils.pbench': [
-                  'Dnf = runperf.utils.pbench:Dnf']},
+                  '50Dnf = runperf.utils.pbench:Dnf']},
           test_suite='selftests',
           python_requires='>=3.4',
           install_requires=['aexpect>=1.5.1', 'PyYAML', 'numpy'])


### PR DESCRIPTION
To make this happen we needed to:

1. unify the plugin naming convention, therefore plugin.name is always
   used as a name (rather than plugin.plugin, plugin.profile, ...)
2. name all entry points (providers used entry point name rather than
   plugin.name)
3. created convenient utils to share the sort implementation
4. prefix the in-tree plugins with 50 to demonstrate the usual naming
   convention.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>