### PR TITLE
Add support to specify custom qemu binary

### DIFF
--- a/contrib/setup_scripts/upstream_qemu.sh
+++ b/contrib/setup_scripts/upstream_qemu.sh
@@ -1,0 +1,17 @@
+#!/bin/bash -x
+# Use '$profile:{"qemu_bin": "/usr/local/bin/qemu-system-$arch"}' to use this qemu
+OLD_PWD="$PWD"
+dnf install -y python3-devel zlib-devel gtk3-devel glib2-static spice-server-devel usbredir-devel make gcc
+dnf install -y libseccomp-devel numactl-devel
+[ -e "/root/qemu" ] || git clone https://github.com/qemu/qemu --depth=1
+cd /root/qemu
+git submodule update --init
+VERSION=$(git rev-parse HEAD)
+git diff --quiet || VERSION+="-dirty"
+#./configure --target-list="$(uname -m)"-softmmu
+./configure --target-list="$(uname -m)"-softmmu --disable-werror --enable-kvm --enable-vhost-net --enable-attr --enable-fdt --enable-vnc --enable-seccomp --enable-spice --enable-usb-redir --with-pkgversion="$VERSION"
+make -j $(getconf _NPROCESSORS_ONLN)
+make install
+chcon -Rt qemu_exec_t /usr/local/bin/qemu-system-"$(uname -m)"
+\cp -f build/config.status /usr/local/share/qemu/
+cd $OLD_PWD

--- a/runperf/__init__.py
+++ b/runperf/__init__.py
@@ -203,7 +203,7 @@ def create_metadata(output_dir, args):
             elif this in ("--host-setup-script", "--worker-setup-script"):
                 with open(cmd[i + 1], 'rb') as script:
                     cmd[i + 1] = "sha1:"
-                    cmd[i + 1] += hashlib.sha1(script.read()).hexdigest()[:6]
+                    cmd[i + 1] += hashlib.sha1(script.read()).hexdigest()[:6]  # nosec
         output.write("runperf_cmd:%s\n" % " ".join(cmd))
         output.write("machine:%s" % ",".join(_[1] for _ in args.hosts))
         if "machine_url_base" in args.metadata:

--- a/runperf/__init__.py
+++ b/runperf/__init__.py
@@ -107,8 +107,6 @@ def _parse_args():
                         "installed on host", nargs="+")
     parser.add_argument("--guest-rpm", help="Url/path(s) to rpm packages to be"
                         " installed on guest(s)", nargs="+")
-    parser.add_argument("--qemu-bin", help="Path to qemu binary to be used "
-                        "to start the guests.")
     parser.add_argument("--keep-tmp-files", action="store_true", help="Keep "
                         "the temporary files (local/remote)")
     parser.add_argument("--output", help="Force output directory (%(default)s",

--- a/runperf/machine.py
+++ b/runperf/machine.py
@@ -745,6 +745,10 @@ class LibvirtGuest(BaseMachine):
                         % (self.image, self.mem, self.name,
                            self._get_os_variant(session),
                            self.smp, image))
+        if "qemu_bin" in self.extra_params:
+            session.cmd("echo -e 'cd /domain/devices/emulator\nset %s\nsave' "
+                        "| xmllint --shell '%s.xml'"
+                        % (self.extra_params['qemu_bin'], image))
 
         # Finally start the machine
         session.cmd("chown -R qemu:qemu /dev/hugepages/")

--- a/runperf/profiles.py
+++ b/runperf/profiles.py
@@ -19,7 +19,6 @@ import time
 from pkg_resources import iter_entry_points as pkg_entry_points
 
 from . import utils
-import json
 
 
 LOG = logging.getLogger(__name__)
@@ -553,7 +552,7 @@ class TunedLibvirt(DefaultLibvirt, PersistentProfile):  # lgtm[py/multiple-calls
         return info
 
 
-def get(profile, host, paths):
+def get(profile, extra, host, paths):
     """
     Get initialized/started guests object matching the definition
 
@@ -562,11 +561,5 @@ def get(profile, host, paths):
     :param tmpdir: Temporary directory for resources
     :return: Initialized and started guests instance (`BaseGuests`)
     """
-    _profile = profile.split(':', 1)
-    if len(_profile) == 2:
-        profile = _profile[0]
-        extra = json.loads(_profile[1])
-    else:
-        extra = {}
     plugin = utils.named_entry_point('runperf.profiles', profile)
     return plugin(host, paths, extra)

--- a/runperf/tests.py
+++ b/runperf/tests.py
@@ -411,17 +411,11 @@ class PBenchNBD(PBenchFio):
             session.cmd("rm -Rf %s" % self.base_path)
         PBenchFio.cleanup(self)
 
-def get(name):
+def get(name, extra):
     """
     Get list of test classes based on test name
 
     :param test_name: Test name optionally followed by ':' and extra params
     :return: instance that allow performing the test and extra params
     """
-    _name = name.split(':', 1)
-    if len(_name) == 2:
-        name = _name[0]
-        extra = json.loads(_name[1])
-    else:
-        extra = {}
     return (utils.named_entry_point('runperf.tests', name), extra)

--- a/selftests/core/test_machine.py
+++ b/selftests/core/test_machine.py
@@ -68,7 +68,7 @@ class ControllerTests(Selftest):
         with mock.patch("runperf.machine.profiles", mod_profiles):
             with mock.patch("runperf.machine.time"):
                 controller = DummyController(self.tmpdir)
-                workers = controller.apply_profile("dummy")
+                workers = controller.apply_profile("dummy", {})
                 self.assertEqual(len(profile.mock_calls), 3,
                                  profile.mock_calls)
                 self.assertEqual(workers, [['worker1', 'worker2']])

--- a/selftests/core/test_profiles.py
+++ b/selftests/core/test_profiles.py
@@ -65,7 +65,7 @@ class ProfileUnitTests(Selftest):
             host = Host(mock.Mock(), "selftest", "addr", "__test_distro__",
                         args)
             host.get_session = lambda *args, **kwargs: ShellSession("sh")
-            profile = Localhost(host, self.tmpdir)
+            profile = Localhost(host, self.tmpdir, {})
             # basic handling
             self.assertEqual(-1, profile._get("foo"))
             obj = object()
@@ -105,7 +105,7 @@ class ProfileUnitTests(Selftest):
             # double revert
             profile.revert()
             # delete active profile
-            profile = Localhost(host, self.tmpdir)
+            profile = Localhost(host, self.tmpdir, {})
             session = profile.session
             del profile
             self.assertTrue(session.closed)
@@ -120,7 +120,7 @@ class ProfileUnitTests(Selftest):
             host = Host(mock.Mock(), "selftest", "addr", "__test_distro__",
                         args)
             host.get_session = lambda *args, **kwargs: ShellSession("sh")
-            profile = DefaultLibvirt(host, self.tmpdir)
+            profile = DefaultLibvirt(host, self.tmpdir, {})
             pubkey = os.path.join(self.tmpdir, "pubkey")
             image = os.path.join(self.tmpdir, "image")
             setup_script = "foo"
@@ -182,7 +182,7 @@ class RunPerfTest(Selftest):
         host.get_session = lambda *args, **kwargs: session
         host.copy_from = shutil.copy
         with mock.patch("runperf.profiles.CONFIG_DIR", runperf_dir):
-            profile = TunedLibvirt(host, [asset_path])
+            profile = TunedLibvirt(host, [asset_path], {})
             profile.selftest_root = runperf_dir
             # Persistent apply, should ask for reboot
             session.cmd.return_value = "some:value"


### PR DESCRIPTION
In order to support upstream-qemu-from-git testing let's add support for extra params to profiles and use it to allow specifying a custom qemu-bin in DefaultLibvirt-like profiles. Also support for extra metadata info.

Fixes: #77 