### PR TITLE
Fix shallow clone workaround

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ jobs:
       env:
         - CC_TEST_REPORTER_ID=009b4c0bfafb850daeb66460df98eded574477a064df0b4a75f65752b18b1d01
       script:
-        - git fetch --depth=1 origin +refs/tags/*:refs/tags/*
+        - git fetch --depth=500
         - pip install coverage
         - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
         - chmod +x ./cc-test-reporter
@@ -22,7 +22,5 @@ jobs:
         - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT
     - name: "Selftests"
       script:
-        - python3 setup.py --version
-        - git fetch --depth=1 origin +refs/tags/*:refs/tags/*
-        - python3 setup.py --version
+        - git fetch --depth=500
         - make check

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,6 @@ check: clean develop
 	@echo "RUNNING SELFTESTS:";
 	$(PYTHON) ./selftests/run
 	@echo RUNNING DOCUMENTATION CHECK:
-	$(PYTHON) setup.py --version
 	make -C docs html SPHINXOPTS="-W --keep-going -n"
 
 coverage: clean develop

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -27,11 +27,11 @@ author = 'Lukáš Doktor'
 
 # The full version, including alpha/beta/rc tags
 release = _get_git_version()
-if release == '0.0̈́':
+if release == '0.0':
     # Probably in shallow-cloned git, fetch the latest tag
     try:
-        subprocess.call([shutil.which("git"), "fetch", "--depth=1",  # nosec
-                         "origin", "+refs/tags/*:refs/tags/*"])
+        subprocess.call([shutil.which("git"), "fetch",  # nosec
+                         "--depth=500"])
         release = _get_git_version()
     except subprocess.SubprocessError:
         pass


### PR DESCRIPTION
There was a utf8 typo in 0.0 string and the tags clone does not work
properly. We really have to checkout everything up to the tag.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>