### PR TITLE
contrib/upstream_qemu_bisect: Checkout the fetched sha

### DIFF
--- a/contrib/upstream_qemu_bisect.sh
+++ b/contrib/upstream_qemu_bisect.sh
@@ -87,6 +87,7 @@ pushd "/root"
 popd
 pushd "/root/qemu"
 git fetch --depth=1 origin "$UPSTREAM_QEMU_COMMIT"
+git checkout "$UPSTREAM_QEMU_COMMIT"
 git submodule update --init
 VERSION=$(git rev-parse HEAD)
 #./configure --target-list="$(uname -m)"-softmmu


### PR DESCRIPTION
We have to checkout the checked-out sha before initializing the
submodules.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>