### PR TITLE
Fix html_report's filters

### DIFF
--- a/docs/source/_static/html_result.html
+++ b/docs/source/_static/html_result.html
@@ -11416,7 +11416,7 @@ function tableOfFailuresFilter() {
 		if (display != "none") {
 			var names = table_of_failures_hide_name_segments.values()
 			for (var name = ""; name = names.next().value;) {
-				if (items[i].querySelectorAll('td')[0].innerText.includes(name)) {
+				if (items[i].querySelectorAll('td')[0].className.includes(name)) {
 					display = "none";
 					break;
 				}
@@ -11482,7 +11482,7 @@ function tableOfGroupFailuresFilter() {
 		if (display != "none") {
 			var names = table_of_group_failures_hide_name_segments.values()
 			for (var name = ""; name = names.next().value;) {
-				if (items[i].querySelectorAll('td')[0].innerText.includes(name)) {
+				if (items[i].querySelectorAll('td')[0].className.includes(name)) {
 					display = "none";
 					break;
 				}

--- a/runperf/assets/html_report/report_template.html
+++ b/runperf/assets/html_report/report_template.html
@@ -10316,7 +10316,7 @@ function tableOfFailuresFilter() {
 		if (display != "none") {
 			var names = table_of_failures_hide_name_segments.values()
 			for (var name = ""; name = names.next().value;) {
-				if (items[i].querySelectorAll('td')[0].innerText.includes(name)) {
+				if (items[i].querySelectorAll('td')[0].className.includes(name)) {
 					display = "none";
 					break;
 				}
@@ -10382,7 +10382,7 @@ function tableOfGroupFailuresFilter() {
 		if (display != "none") {
 			var names = table_of_group_failures_hide_name_segments.values()
 			for (var name = ""; name = names.next().value;) {
-				if (items[i].querySelectorAll('td')[0].innerText.includes(name)) {
+				if (items[i].querySelectorAll('td')[0].className.includes(name)) {
 					display = "none";
 					break;
 				}


### PR DESCRIPTION
The filters were based on hidden element's innerText which includes the
full row when the display==none and result in incorrect filters being
applied. Let's use the className instead as that one contains the full
name of the test and is more reliable.

Fixes: #108