### PR TITLE
Use disown to run qemu-nbd

### DIFF
--- a/runperf/tests.py
+++ b/runperf/tests.py
@@ -394,6 +394,9 @@ class PBenchNBD(PBenchFio):
                                 "$(mktemp %s/qemu_nbd_XXXX.log)"
                                 " & echo $! >> %s/kill_pids"
                                 % ((self.base_path,) * 4))
+                    # Sometimes nohup is not enough, use disown
+                    session.cmd("for PID in $(cat %s/kill_pids); do "
+                                "disown -h $PID; done" % self.base_path)
         with self.host.get_session_cont(hop=self.host) as session:
             session.cmd("mkdir -p " + self.base_path)
             session.cmd(fio_tpl)


### PR DESCRIPTION
Sometimes the qemu-nbd get's killed even when nohup is used. Let's use
disown to make sure it keeps running in the background.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>