### PR TITLE
tests: Overwrite potentially existing results.json.backup

### DIFF
--- a/runperf/tests.py
+++ b/runperf/tests.py
@@ -91,7 +91,7 @@ class BaseTest:
                               for worker in workers}
         meta['workers'] = str_workers
         if session.cmd_status("[ -e '%s' ]" % path) == 0:
-            session.cmd("cp '%s' '%s.backup'" % (path, path))
+            session.cmd("cp -f '%s' '%s.backup'" % (path, path))
             results = json.loads(session.cmd_output("cat '%s'" % path,
                                                     timeout=600,
                                                     print_func='mute'))

--- a/selftests/core/test_tests.py
+++ b/selftests/core/test_tests.py
@@ -72,7 +72,7 @@ class PBenchTest(Selftest):
                 test.cleanup()
 
         calls = [exp_cmdline, "[ -e '%s/result.json' ]" % result_path,
-                 "cp '%s/result.json' '%s/result.json.backup'"
+                 "cp -f '%s/result.json' '%s/result.json.backup'"
                  % (result_path, result_path)]
         if "pbench_server_publish" in metadata:
             calls.append('pbench-copy-results --user asdf --prefix fdsa')


### PR DESCRIPTION
Force the copy in the case the results.json.backup already existed.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>