### PR TITLE
Add our profile to the processed test_params

### DIFF
--- a/docs/source/_static/html_result.html
+++ b/docs/source/_static/html_result.html
@@ -12069,11 +12069,11 @@ Localhost2/fio/0000:./read-64KiB/throughput/iops_sec.stddev</pre></span></div></
     </tr>
     
     <tr class=" status_-1 any_status_-1 any_status_-1 any_status_-1 ">
-        <td class="status_Localhost/fio/0000:./read-4KiB/throughput/iops_sec.mean"><div class="tooltip" onclick="elementValueToClipboard('env-test-1-1-raw')">Localhost/fio/0000:./read-4KiB/throughput/iops_sec.mean<textarea style="position: absolute; left: -9999px;"  id="env-test-1-1-raw">{0: &#39;benchmark_name:fio\nbs:4k\nclocksource:gettimeofday\ndirect:1\nfilename:/fio\niodepth:32\nioengine:libaio\nlog_avg_msec:1000\nlog_hist_msec:10000\nmax_stddevpct:5\nnumjobs:1\nprimary_metric:iops_sec\nramp_time:5\nruntime:60\nrw:read\nsize:1300000\nsync:0\ntime_based:1\nuid:benchmark_name:%benchmark_name%-controller_host:%controller_host%&#39;}</textarea>&#x1f527;<span class="tooltiptext">Localhost/fio/0000:./read-4KiB/throughput/iops_sec.mean<br><a href='#'>Click to copy raw src test params</a></span></div></td>
+        <td class="status_Localhost/fio/0000:./read-4KiB/throughput/iops_sec.mean"><div class="tooltip" onclick="elementValueToClipboard('env-test-1-1-raw')">Localhost/fio/0000:./read-4KiB/throughput/iops_sec.mean<textarea style="position: absolute; left: -9999px;"  id="env-test-1-1-raw">{0: &#39;benchmark_name:fio\nbs:4k\nclocksource:gettimeofday\ndirect:1\nfilename:/fio\niodepth:32\nioengine:libaio\nlog_avg_msec:1000\nlog_hist_msec:10000\nmax_stddevpct:5\nnumjobs:1\nprimary_metric:iops_sec\nramp_time:5\nruntime:60\nrw:read\nsize:1300000\nsync:0\ntime_based:1\nuid:benchmark_name:%benchmark_name%-controller_host:%controller_host%&#39;, &#39;user0&#39;: &#39;profile: Localhost&#39;}</textarea>&#x1f527;<span class="tooltiptext">Localhost/fio/0000:./read-4KiB/throughput/iops_sec.mean<br><a href='#'>Click to copy raw src test params</a></span></div></td>
         <td class="status_2"><div class="tooltip" onclick="elementValueToClipboard('env-test-1-2-raw')">-1.3<span class="tooltiptext">GOOD model0 -1.26%, mraw0 -1.21%, raw -3.57% (179348.46/183743.17; 177181.152542373) +-5.0% tolerance</span></div></td>
         <td class="status_-1"><div class="tooltip" onclick="elementValueToClipboard('env-test-1-3-raw')">-6.1<span class="tooltiptext">SMALL model0 -6.07%, mraw0 -5.63%, raw -7.89% (179348.46/183743.17; 169245.372881356) +-5.0% tolerance</span></div></td>
         <td class="status_-1"><div class="tooltip" onclick="elementValueToClipboard('env-test-1-4-raw')">-20.2<span class="tooltiptext">SMALL model0 -20.25%, mraw0 -18.69%, raw -20.64% (179348.46/183743.17; 145825.271186441) +-5.0% tolerance</span></div></td>
-        <td class="status_-1"><div class="tooltip" onclick="elementValueToClipboard('env-test-1-5-raw')">-9.6<textarea style="position: absolute; left: -9999px;"  id="env-test-1-5-raw">{0: &#39;benchmark_name:fio\nbs:4k\nclocksource:gettimeofday\ndirect:1\nfilename:/fio\niodepth:32\nioengine:libaio\nlog_avg_msec:1000\nlog_hist_msec:10000\nmax_stddevpct:5\nnumjobs:1\nprimary_metric:iops_sec\nramp_time:5\nruntime:61\nrw:read\nsize:1300000\nsync:0\ntime_based:1\nuid:benchmark_name:%benchmark_name%-controller_host:%controller_host%&#39;}</textarea>&#x1f527;<span class="tooltiptext">SMALL raw -6.83%, avg -16.23% GOOD model0 -4.88%, mraw0 -4.54% (179348.46/183743.17; 171197.389830508) +-5.0% tolerance<br><a href='#'>Test params differ (click to copy raw value):</a><pre>
+        <td class="status_-1"><div class="tooltip" onclick="elementValueToClipboard('env-test-1-5-raw')">-9.6<textarea style="position: absolute; left: -9999px;"  id="env-test-1-5-raw">{0: &#39;benchmark_name:fio\nbs:4k\nclocksource:gettimeofday\ndirect:1\nfilename:/fio\niodepth:32\nioengine:libaio\nlog_avg_msec:1000\nlog_hist_msec:10000\nmax_stddevpct:5\nnumjobs:1\nprimary_metric:iops_sec\nramp_time:5\nruntime:61\nrw:read\nsize:1300000\nsync:0\ntime_based:1\nuid:benchmark_name:%benchmark_name%-controller_host:%controller_host%&#39;, &#39;user0&#39;: &#39;profile: Localhost&#39;}</textarea>&#x1f527;<span class="tooltiptext">SMALL raw -6.83%, avg -16.23% GOOD model0 -4.88%, mraw0 -4.54% (179348.46/183743.17; 171197.389830508) +-5.0% tolerance<br><a href='#'>Test params differ (click to copy raw value):</a><pre>
 0
 =
 -runtime:60
@@ -12081,11 +12081,11 @@ Localhost2/fio/0000:./read-64KiB/throughput/iops_sec.stddev</pre></span></div></
     </tr>
     
     <tr class=" status_2 any_status_2 any_status_2 any_status_2 ">
-        <td class="status_Localhost/fio/0000:./read-4KiB/throughput/iops_sec.stddev"><div class="tooltip" onclick="elementValueToClipboard('env-test-2-1-raw')">Localhost/fio/0000:./read-4KiB/throughput/iops_sec.stddev<textarea style="position: absolute; left: -9999px;"  id="env-test-2-1-raw">{0: &#39;benchmark_name:fio\nbs:4k\nclocksource:gettimeofday\ndirect:1\nfilename:/fio\niodepth:32\nioengine:libaio\nlog_avg_msec:1000\nlog_hist_msec:10000\nmax_stddevpct:5\nnumjobs:1\nprimary_metric:iops_sec\nramp_time:5\nruntime:60\nrw:read\nsize:1300000\nsync:0\ntime_based:1\nuid:benchmark_name:%benchmark_name%-controller_host:%controller_host%&#39;}</textarea>&#x1f527;<span class="tooltiptext">Localhost/fio/0000:./read-4KiB/throughput/iops_sec.stddev<br><a href='#'>Click to copy raw src test params</a></span></div></td>
+        <td class="status_Localhost/fio/0000:./read-4KiB/throughput/iops_sec.stddev"><div class="tooltip" onclick="elementValueToClipboard('env-test-2-1-raw')">Localhost/fio/0000:./read-4KiB/throughput/iops_sec.stddev<textarea style="position: absolute; left: -9999px;"  id="env-test-2-1-raw">{0: &#39;benchmark_name:fio\nbs:4k\nclocksource:gettimeofday\ndirect:1\nfilename:/fio\niodepth:32\nioengine:libaio\nlog_avg_msec:1000\nlog_hist_msec:10000\nmax_stddevpct:5\nnumjobs:1\nprimary_metric:iops_sec\nramp_time:5\nruntime:60\nrw:read\nsize:1300000\nsync:0\ntime_based:1\nuid:benchmark_name:%benchmark_name%-controller_host:%controller_host%&#39;, &#39;user0&#39;: &#39;profile: Localhost&#39;}</textarea>&#x1f527;<span class="tooltiptext">Localhost/fio/0000:./read-4KiB/throughput/iops_sec.stddev<br><a href='#'>Click to copy raw src test params</a></span></div></td>
         <td class="status_2"><div class="tooltip" onclick="elementValueToClipboard('env-test-2-2-raw')">0.0<span class="tooltiptext">GOOD raw 0.00% (0.00; 0) +-10.0% tolerance</span></div></td>
         <td class="status_2"><div class="tooltip" onclick="elementValueToClipboard('env-test-2-3-raw')">0.0<span class="tooltiptext">GOOD raw 0.00% (0.00; 0) +-10.0% tolerance</span></div></td>
         <td class="status_2"><div class="tooltip" onclick="elementValueToClipboard('env-test-2-4-raw')">0.0<span class="tooltiptext">GOOD raw 0.00% (0.00; 0) +-10.0% tolerance</span></div></td>
-        <td class="status_2"><div class="tooltip" onclick="elementValueToClipboard('env-test-2-5-raw')">0.0<textarea style="position: absolute; left: -9999px;"  id="env-test-2-5-raw">{0: &#39;benchmark_name:fio\nbs:4k\nclocksource:gettimeofday\ndirect:1\nfilename:/fio\niodepth:32\nioengine:libaio\nlog_avg_msec:1000\nlog_hist_msec:10000\nmax_stddevpct:5\nnumjobs:1\nprimary_metric:iops_sec\nramp_time:5\nruntime:61\nrw:read\nsize:1300000\nsync:0\ntime_based:1\nuid:benchmark_name:%benchmark_name%-controller_host:%controller_host%&#39;}</textarea>&#x1f527;<span class="tooltiptext">GOOD raw 0.00%, avg 0.00% (0.00; 0) +-10.0% tolerance<br><a href='#'>Test params differ (click to copy raw value):</a><pre>
+        <td class="status_2"><div class="tooltip" onclick="elementValueToClipboard('env-test-2-5-raw')">0.0<textarea style="position: absolute; left: -9999px;"  id="env-test-2-5-raw">{0: &#39;benchmark_name:fio\nbs:4k\nclocksource:gettimeofday\ndirect:1\nfilename:/fio\niodepth:32\nioengine:libaio\nlog_avg_msec:1000\nlog_hist_msec:10000\nmax_stddevpct:5\nnumjobs:1\nprimary_metric:iops_sec\nramp_time:5\nruntime:61\nrw:read\nsize:1300000\nsync:0\ntime_based:1\nuid:benchmark_name:%benchmark_name%-controller_host:%controller_host%&#39;, &#39;user0&#39;: &#39;profile: Localhost&#39;}</textarea>&#x1f527;<span class="tooltiptext">GOOD raw 0.00%, avg 0.00% (0.00; 0) +-10.0% tolerance<br><a href='#'>Test params differ (click to copy raw value):</a><pre>
 0
 =
 -runtime:60
@@ -12093,11 +12093,11 @@ Localhost2/fio/0000:./read-64KiB/throughput/iops_sec.stddev</pre></span></div></
     </tr>
     
     <tr class=" status_-3 any_status_1 any_status_1 any_status_-3 ">
-        <td class="status_Localhost/fio/0000:./read-64KiB/throughput/iops_sec.mean"><div class="tooltip" onclick="elementValueToClipboard('env-test-3-1-raw')">Localhost/fio/0000:./read-64KiB/throughput/iops_sec.mean<textarea style="position: absolute; left: -9999px;"  id="env-test-3-1-raw">{0: &#39;benchmark_name:fio\nbs:64k\nclocksource:gettimeofday\ndirect:1\nfilename:/fio\niodepth:32\nioengine:libaio\nlog_avg_msec:1000\nlog_hist_msec:10000\nmax_stddevpct:5\nnumjobs:1\nprimary_metric:iops_sec\nramp_time:5\nruntime:60\nrw:read\nsize:1300000\nsync:0\ntime_based:1\nuid:benchmark_name:%benchmark_name%-controller_host:%controller_host%&#39;}</textarea>&#x1f527;<span class="tooltiptext">Localhost/fio/0000:./read-64KiB/throughput/iops_sec.mean<br><a href='#'>Click to copy raw src test params</a></span></div></td>
+        <td class="status_Localhost/fio/0000:./read-64KiB/throughput/iops_sec.mean"><div class="tooltip" onclick="elementValueToClipboard('env-test-3-1-raw')">Localhost/fio/0000:./read-64KiB/throughput/iops_sec.mean<textarea style="position: absolute; left: -9999px;"  id="env-test-3-1-raw">{0: &#39;benchmark_name:fio\nbs:64k\nclocksource:gettimeofday\ndirect:1\nfilename:/fio\niodepth:32\nioengine:libaio\nlog_avg_msec:1000\nlog_hist_msec:10000\nmax_stddevpct:5\nnumjobs:1\nprimary_metric:iops_sec\nramp_time:5\nruntime:60\nrw:read\nsize:1300000\nsync:0\ntime_based:1\nuid:benchmark_name:%benchmark_name%-controller_host:%controller_host%&#39;, &#39;user0&#39;: &#39;profile: Localhost&#39;}</textarea>&#x1f527;<span class="tooltiptext">Localhost/fio/0000:./read-64KiB/throughput/iops_sec.mean<br><a href='#'>Click to copy raw src test params</a></span></div></td>
         <td class="status_-1"><div class="tooltip" onclick="elementValueToClipboard('env-test-3-2-raw')">-6.8<span class="tooltiptext">SMALL model0 -6.75%, mraw0 -6.14%, raw -8.70% (100482.88/103308.03; 94316.7627118644) +-5.0% tolerance</span></div></td>
         <td class="status_1"><div class="tooltip" onclick="elementValueToClipboard('env-test-3-3-raw')">3.9<span class="tooltiptext">GOOD model0 3.94%, mraw0 3.58%, raw 0.75% (100482.88/103308.03; 104077.847457627) +-5.0% tolerance</span></div></td>
         <td class="status_1"><div class="tooltip" onclick="elementValueToClipboard('env-test-3-4-raw')">2.9<span class="tooltiptext">GOOD model0 2.91%, mraw0 2.64%, raw -0.16% (100482.88/103308.03; 103140.627118644) +-5.0% tolerance</span></div></td>
-        <td class="status_-3"><div class="tooltip" onclick="elementValueToClipboard('env-test-3-5-raw')">17.3<textarea style="position: absolute; left: -9999px;"  id="env-test-3-5-raw">{0: &#39;benchmark_name:fio\nbs:64k\nclocksource:gettimeofday\ndirect:1\nfilename:/fio\niodepth:32\nioengine:libaio\nlog_avg_msec:1000\nlog_hist_msec:10000\nmax_stddevpct:5\nnumjobs:1\nprimary_metric:iops_sec\nramp_time:5\nruntime:61\nrw:read\nsize:1300000\nsync:0\ntime_based:1\nuid:benchmark_name:%benchmark_name%-controller_host:%controller_host%&#39;}</textarea>&#x1f527;<span class="tooltiptext">BIG model0 21.78%, mraw0 19.80%, raw 16.53%, avg 10.94% (100482.88/103308.03; 120381.830508475) +-5.0% tolerance<br><a href='#'>Test params differ (click to copy raw value):</a><pre>
+        <td class="status_-3"><div class="tooltip" onclick="elementValueToClipboard('env-test-3-5-raw')">17.3<textarea style="position: absolute; left: -9999px;"  id="env-test-3-5-raw">{0: &#39;benchmark_name:fio\nbs:64k\nclocksource:gettimeofday\ndirect:1\nfilename:/fio\niodepth:32\nioengine:libaio\nlog_avg_msec:1000\nlog_hist_msec:10000\nmax_stddevpct:5\nnumjobs:1\nprimary_metric:iops_sec\nramp_time:5\nruntime:61\nrw:read\nsize:1300000\nsync:0\ntime_based:1\nuid:benchmark_name:%benchmark_name%-controller_host:%controller_host%&#39;, &#39;user0&#39;: &#39;profile: Localhost&#39;}</textarea>&#x1f527;<span class="tooltiptext">BIG model0 21.78%, mraw0 19.80%, raw 16.53%, avg 10.94% (100482.88/103308.03; 120381.830508475) +-5.0% tolerance<br><a href='#'>Test params differ (click to copy raw value):</a><pre>
 0
 =
 -runtime:60
@@ -12105,11 +12105,11 @@ Localhost2/fio/0000:./read-64KiB/throughput/iops_sec.stddev</pre></span></div></
     </tr>
     
     <tr class=" status_2 any_status_2 any_status_2 any_status_2 ">
-        <td class="status_Localhost/fio/0000:./read-64KiB/throughput/iops_sec.stddev"><div class="tooltip" onclick="elementValueToClipboard('env-test-4-1-raw')">Localhost/fio/0000:./read-64KiB/throughput/iops_sec.stddev<textarea style="position: absolute; left: -9999px;"  id="env-test-4-1-raw">{0: &#39;benchmark_name:fio\nbs:64k\nclocksource:gettimeofday\ndirect:1\nfilename:/fio\niodepth:32\nioengine:libaio\nlog_avg_msec:1000\nlog_hist_msec:10000\nmax_stddevpct:5\nnumjobs:1\nprimary_metric:iops_sec\nramp_time:5\nruntime:60\nrw:read\nsize:1300000\nsync:0\ntime_based:1\nuid:benchmark_name:%benchmark_name%-controller_host:%controller_host%&#39;}</textarea>&#x1f527;<span class="tooltiptext">Localhost/fio/0000:./read-64KiB/throughput/iops_sec.stddev<br><a href='#'>Click to copy raw src test params</a></span></div></td>
+        <td class="status_Localhost/fio/0000:./read-64KiB/throughput/iops_sec.stddev"><div class="tooltip" onclick="elementValueToClipboard('env-test-4-1-raw')">Localhost/fio/0000:./read-64KiB/throughput/iops_sec.stddev<textarea style="position: absolute; left: -9999px;"  id="env-test-4-1-raw">{0: &#39;benchmark_name:fio\nbs:64k\nclocksource:gettimeofday\ndirect:1\nfilename:/fio\niodepth:32\nioengine:libaio\nlog_avg_msec:1000\nlog_hist_msec:10000\nmax_stddevpct:5\nnumjobs:1\nprimary_metric:iops_sec\nramp_time:5\nruntime:60\nrw:read\nsize:1300000\nsync:0\ntime_based:1\nuid:benchmark_name:%benchmark_name%-controller_host:%controller_host%&#39;, &#39;user0&#39;: &#39;profile: Localhost&#39;}</textarea>&#x1f527;<span class="tooltiptext">Localhost/fio/0000:./read-64KiB/throughput/iops_sec.stddev<br><a href='#'>Click to copy raw src test params</a></span></div></td>
         <td class="status_2"><div class="tooltip" onclick="elementValueToClipboard('env-test-4-2-raw')">0.0<span class="tooltiptext">GOOD raw 0.00% (0.00; 0) +-10.0% tolerance</span></div></td>
         <td class="status_2"><div class="tooltip" onclick="elementValueToClipboard('env-test-4-3-raw')">0.0<span class="tooltiptext">GOOD raw 0.00% (0.00; 0) +-10.0% tolerance</span></div></td>
         <td class="status_2"><div class="tooltip" onclick="elementValueToClipboard('env-test-4-4-raw')">0.0<span class="tooltiptext">GOOD raw 0.00% (0.00; 0) +-10.0% tolerance</span></div></td>
-        <td class="status_2"><div class="tooltip" onclick="elementValueToClipboard('env-test-4-5-raw')">0.0<textarea style="position: absolute; left: -9999px;"  id="env-test-4-5-raw">{0: &#39;benchmark_name:fio\nbs:64k\nclocksource:gettimeofday\ndirect:1\nfilename:/fio\niodepth:32\nioengine:libaio\nlog_avg_msec:1000\nlog_hist_msec:10000\nmax_stddevpct:5\nnumjobs:1\nprimary_metric:iops_sec\nramp_time:5\nruntime:61\nrw:read\nsize:1300000\nsync:0\ntime_based:1\nuid:benchmark_name:%benchmark_name%-controller_host:%controller_host%&#39;}</textarea>&#x1f527;<span class="tooltiptext">GOOD raw 0.00%, avg 0.00% (0.00; 0) +-10.0% tolerance<br><a href='#'>Test params differ (click to copy raw value):</a><pre>
+        <td class="status_2"><div class="tooltip" onclick="elementValueToClipboard('env-test-4-5-raw')">0.0<textarea style="position: absolute; left: -9999px;"  id="env-test-4-5-raw">{0: &#39;benchmark_name:fio\nbs:64k\nclocksource:gettimeofday\ndirect:1\nfilename:/fio\niodepth:32\nioengine:libaio\nlog_avg_msec:1000\nlog_hist_msec:10000\nmax_stddevpct:5\nnumjobs:1\nprimary_metric:iops_sec\nramp_time:5\nruntime:61\nrw:read\nsize:1300000\nsync:0\ntime_based:1\nuid:benchmark_name:%benchmark_name%-controller_host:%controller_host%&#39;, &#39;user0&#39;: &#39;profile: Localhost&#39;}</textarea>&#x1f527;<span class="tooltiptext">GOOD raw 0.00%, avg 0.00% (0.00; 0) +-10.0% tolerance<br><a href='#'>Test params differ (click to copy raw value):</a><pre>
 0
 =
 -runtime:60
@@ -12117,82 +12117,130 @@ Localhost2/fio/0000:./read-64KiB/throughput/iops_sec.stddev</pre></span></div></
     </tr>
     
     <tr class=" status_-2 any_status_-2 any_status_-2 any_status_-2 ">
-        <td class="status_Localhost2/fio/0000:./read-4KiB/throughput/iops_sec.mean"><div class="tooltip" onclick="elementValueToClipboard('env-test-5-1-raw')">Localhost2/fio/0000:./read-4KiB/throughput/iops_sec.mean<textarea style="position: absolute; left: -9999px;"  id="env-test-5-1-raw">{0: &#39;benchmark_name:fio\nbs:4k\nclocksource:gettimeofday\ndirect:1\nfilename:/fio\niodepth:32\nioengine:libaio\nlog_avg_msec:1000\nlog_hist_msec:10000\nmax_stddevpct:5\nnumjobs:1\nprimary_metric:iops_sec\nramp_time:5\nruntime:60\nrw:read\nsize:1300000\nsync:0\ntime_based:1\nuid:benchmark_name:%benchmark_name%-controller_host:%controller_host%&#39;}</textarea>&#x1f527;<span class="tooltiptext">Localhost2/fio/0000:./read-4KiB/throughput/iops_sec.mean<br><a href='#'>Click to copy raw src test params</a></span></div></td>
-        <td class="status_-2"><div class="tooltip" onclick="elementValueToClipboard('env-test-5-2-raw')">-100.0<textarea style="position: absolute; left: -9999px;"  id="env-test-5-2-raw">{0: &#39;&#39;}</textarea>&#x1f527;<span class="tooltiptext">Not present in target results (-100)<br><a href='#'>Test params differ (click to copy raw value):</a><pre>
+        <td class="status_Localhost2/fio/0000:./read-4KiB/throughput/iops_sec.mean"><div class="tooltip" onclick="elementValueToClipboard('env-test-5-1-raw')">Localhost2/fio/0000:./read-4KiB/throughput/iops_sec.mean<textarea style="position: absolute; left: -9999px;"  id="env-test-5-1-raw">{0: &#39;benchmark_name:fio\nbs:4k\nclocksource:gettimeofday\ndirect:1\nfilename:/fio\niodepth:32\nioengine:libaio\nlog_avg_msec:1000\nlog_hist_msec:10000\nmax_stddevpct:5\nnumjobs:1\nprimary_metric:iops_sec\nramp_time:5\nruntime:60\nrw:read\nsize:1300000\nsync:0\ntime_based:1\nuid:benchmark_name:%benchmark_name%-controller_host:%controller_host%&#39;, &#39;user0&#39;: &#39;profile: Localhost&#39;}</textarea>&#x1f527;<span class="tooltiptext">Localhost2/fio/0000:./read-4KiB/throughput/iops_sec.mean<br><a href='#'>Click to copy raw src test params</a></span></div></td>
+        <td class="status_-2"><div class="tooltip" onclick="elementValueToClipboard('env-test-5-2-raw')">-100.0<textarea style="position: absolute; left: -9999px;"  id="env-test-5-2-raw">{0: &#39;&#39;, &#39;user0&#39;: &#39;&#39;}</textarea>&#x1f527;<span class="tooltiptext">Not present in target results (-100)<br><a href='#'>Test params differ (click to copy raw value):</a><pre>
 0
 =
+-MISSING IN THIS PARAMS
+user0
+=====
 -MISSING IN THIS PARAMS</pre></span></div></td>
-        <td class="status_-2"><div class="tooltip" onclick="elementValueToClipboard('env-test-5-3-raw')">-100.0<textarea style="position: absolute; left: -9999px;"  id="env-test-5-3-raw">{0: &#39;&#39;}</textarea>&#x1f527;<span class="tooltiptext">Not present in target results (-100)<br><a href='#'>Test params differ (click to copy raw value):</a><pre>
+        <td class="status_-2"><div class="tooltip" onclick="elementValueToClipboard('env-test-5-3-raw')">-100.0<textarea style="position: absolute; left: -9999px;"  id="env-test-5-3-raw">{0: &#39;&#39;, &#39;user0&#39;: &#39;&#39;}</textarea>&#x1f527;<span class="tooltiptext">Not present in target results (-100)<br><a href='#'>Test params differ (click to copy raw value):</a><pre>
 0
 =
+-MISSING IN THIS PARAMS
+user0
+=====
 -MISSING IN THIS PARAMS</pre></span></div></td>
-        <td class="status_-2"><div class="tooltip" onclick="elementValueToClipboard('env-test-5-4-raw')">-100.0<textarea style="position: absolute; left: -9999px;"  id="env-test-5-4-raw">{0: &#39;&#39;}</textarea>&#x1f527;<span class="tooltiptext">Not present in target results (-100)<br><a href='#'>Test params differ (click to copy raw value):</a><pre>
+        <td class="status_-2"><div class="tooltip" onclick="elementValueToClipboard('env-test-5-4-raw')">-100.0<textarea style="position: absolute; left: -9999px;"  id="env-test-5-4-raw">{0: &#39;&#39;, &#39;user0&#39;: &#39;&#39;}</textarea>&#x1f527;<span class="tooltiptext">Not present in target results (-100)<br><a href='#'>Test params differ (click to copy raw value):</a><pre>
 0
 =
+-MISSING IN THIS PARAMS
+user0
+=====
 -MISSING IN THIS PARAMS</pre></span></div></td>
-        <td class="status_-2"><div class="tooltip" onclick="elementValueToClipboard('env-test-5-5-raw')">-100.0<textarea style="position: absolute; left: -9999px;"  id="env-test-5-5-raw">{0: &#39;&#39;}</textarea>&#x1f527;<span class="tooltiptext">Not present in target results (-100)<br><a href='#'>Test params differ (click to copy raw value):</a><pre>
+        <td class="status_-2"><div class="tooltip" onclick="elementValueToClipboard('env-test-5-5-raw')">-100.0<textarea style="position: absolute; left: -9999px;"  id="env-test-5-5-raw">{0: &#39;&#39;, &#39;user0&#39;: &#39;&#39;}</textarea>&#x1f527;<span class="tooltiptext">Not present in target results (-100)<br><a href='#'>Test params differ (click to copy raw value):</a><pre>
 0
 =
--MISSING IN THIS PARAMS</pre></span></div></td>
-    </tr>
-    
-    <tr class=" status_-2 any_status_-2 any_status_-2 any_status_-2 ">
-        <td class="status_Localhost2/fio/0000:./read-4KiB/throughput/iops_sec.stddev"><div class="tooltip" onclick="elementValueToClipboard('env-test-6-1-raw')">Localhost2/fio/0000:./read-4KiB/throughput/iops_sec.stddev<textarea style="position: absolute; left: -9999px;"  id="env-test-6-1-raw">{0: &#39;benchmark_name:fio\nbs:4k\nclocksource:gettimeofday\ndirect:1\nfilename:/fio\niodepth:32\nioengine:libaio\nlog_avg_msec:1000\nlog_hist_msec:10000\nmax_stddevpct:5\nnumjobs:1\nprimary_metric:iops_sec\nramp_time:5\nruntime:60\nrw:read\nsize:1300000\nsync:0\ntime_based:1\nuid:benchmark_name:%benchmark_name%-controller_host:%controller_host%&#39;}</textarea>&#x1f527;<span class="tooltiptext">Localhost2/fio/0000:./read-4KiB/throughput/iops_sec.stddev<br><a href='#'>Click to copy raw src test params</a></span></div></td>
-        <td class="status_-2"><div class="tooltip" onclick="elementValueToClipboard('env-test-6-2-raw')">-100.0<textarea style="position: absolute; left: -9999px;"  id="env-test-6-2-raw">{0: &#39;&#39;}</textarea>&#x1f527;<span class="tooltiptext">Not present in target results (-100)<br><a href='#'>Test params differ (click to copy raw value):</a><pre>
-0
-=
--MISSING IN THIS PARAMS</pre></span></div></td>
-        <td class="status_-2"><div class="tooltip" onclick="elementValueToClipboard('env-test-6-3-raw')">-100.0<textarea style="position: absolute; left: -9999px;"  id="env-test-6-3-raw">{0: &#39;&#39;}</textarea>&#x1f527;<span class="tooltiptext">Not present in target results (-100)<br><a href='#'>Test params differ (click to copy raw value):</a><pre>
-0
-=
--MISSING IN THIS PARAMS</pre></span></div></td>
-        <td class="status_-2"><div class="tooltip" onclick="elementValueToClipboard('env-test-6-4-raw')">-100.0<textarea style="position: absolute; left: -9999px;"  id="env-test-6-4-raw">{0: &#39;&#39;}</textarea>&#x1f527;<span class="tooltiptext">Not present in target results (-100)<br><a href='#'>Test params differ (click to copy raw value):</a><pre>
-0
-=
--MISSING IN THIS PARAMS</pre></span></div></td>
-        <td class="status_-2"><div class="tooltip" onclick="elementValueToClipboard('env-test-6-5-raw')">-100.0<textarea style="position: absolute; left: -9999px;"  id="env-test-6-5-raw">{0: &#39;&#39;}</textarea>&#x1f527;<span class="tooltiptext">Not present in target results (-100)<br><a href='#'>Test params differ (click to copy raw value):</a><pre>
-0
-=
+-MISSING IN THIS PARAMS
+user0
+=====
 -MISSING IN THIS PARAMS</pre></span></div></td>
     </tr>
     
     <tr class=" status_-2 any_status_-2 any_status_-2 any_status_-2 ">
-        <td class="status_Localhost2/fio/0000:./read-64KiB/throughput/iops_sec.mean"><div class="tooltip" onclick="elementValueToClipboard('env-test-7-1-raw')">Localhost2/fio/0000:./read-64KiB/throughput/iops_sec.mean<textarea style="position: absolute; left: -9999px;"  id="env-test-7-1-raw">{0: &#39;benchmark_name:fio\nbs:64k\nclocksource:gettimeofday\ndirect:1\nfilename:/fio\niodepth:32\nioengine:libaio\nlog_avg_msec:1000\nlog_hist_msec:10000\nmax_stddevpct:5\nnumjobs:1\nprimary_metric:iops_sec\nramp_time:5\nruntime:60\nrw:read\nsize:1300000\nsync:0\ntime_based:1\nuid:benchmark_name:%benchmark_name%-controller_host:%controller_host%&#39;}</textarea>&#x1f527;<span class="tooltiptext">Localhost2/fio/0000:./read-64KiB/throughput/iops_sec.mean<br><a href='#'>Click to copy raw src test params</a></span></div></td>
-        <td class="status_-2"><div class="tooltip" onclick="elementValueToClipboard('env-test-7-2-raw')">-100.0<textarea style="position: absolute; left: -9999px;"  id="env-test-7-2-raw">{0: &#39;&#39;}</textarea>&#x1f527;<span class="tooltiptext">Not present in target results (-100)<br><a href='#'>Test params differ (click to copy raw value):</a><pre>
+        <td class="status_Localhost2/fio/0000:./read-4KiB/throughput/iops_sec.stddev"><div class="tooltip" onclick="elementValueToClipboard('env-test-6-1-raw')">Localhost2/fio/0000:./read-4KiB/throughput/iops_sec.stddev<textarea style="position: absolute; left: -9999px;"  id="env-test-6-1-raw">{0: &#39;benchmark_name:fio\nbs:4k\nclocksource:gettimeofday\ndirect:1\nfilename:/fio\niodepth:32\nioengine:libaio\nlog_avg_msec:1000\nlog_hist_msec:10000\nmax_stddevpct:5\nnumjobs:1\nprimary_metric:iops_sec\nramp_time:5\nruntime:60\nrw:read\nsize:1300000\nsync:0\ntime_based:1\nuid:benchmark_name:%benchmark_name%-controller_host:%controller_host%&#39;, &#39;user0&#39;: &#39;profile: Localhost&#39;}</textarea>&#x1f527;<span class="tooltiptext">Localhost2/fio/0000:./read-4KiB/throughput/iops_sec.stddev<br><a href='#'>Click to copy raw src test params</a></span></div></td>
+        <td class="status_-2"><div class="tooltip" onclick="elementValueToClipboard('env-test-6-2-raw')">-100.0<textarea style="position: absolute; left: -9999px;"  id="env-test-6-2-raw">{0: &#39;&#39;, &#39;user0&#39;: &#39;&#39;}</textarea>&#x1f527;<span class="tooltiptext">Not present in target results (-100)<br><a href='#'>Test params differ (click to copy raw value):</a><pre>
 0
 =
+-MISSING IN THIS PARAMS
+user0
+=====
 -MISSING IN THIS PARAMS</pre></span></div></td>
-        <td class="status_-2"><div class="tooltip" onclick="elementValueToClipboard('env-test-7-3-raw')">-100.0<textarea style="position: absolute; left: -9999px;"  id="env-test-7-3-raw">{0: &#39;&#39;}</textarea>&#x1f527;<span class="tooltiptext">Not present in target results (-100)<br><a href='#'>Test params differ (click to copy raw value):</a><pre>
+        <td class="status_-2"><div class="tooltip" onclick="elementValueToClipboard('env-test-6-3-raw')">-100.0<textarea style="position: absolute; left: -9999px;"  id="env-test-6-3-raw">{0: &#39;&#39;, &#39;user0&#39;: &#39;&#39;}</textarea>&#x1f527;<span class="tooltiptext">Not present in target results (-100)<br><a href='#'>Test params differ (click to copy raw value):</a><pre>
 0
 =
+-MISSING IN THIS PARAMS
+user0
+=====
 -MISSING IN THIS PARAMS</pre></span></div></td>
-        <td class="status_-2"><div class="tooltip" onclick="elementValueToClipboard('env-test-7-4-raw')">-100.0<textarea style="position: absolute; left: -9999px;"  id="env-test-7-4-raw">{0: &#39;&#39;}</textarea>&#x1f527;<span class="tooltiptext">Not present in target results (-100)<br><a href='#'>Test params differ (click to copy raw value):</a><pre>
+        <td class="status_-2"><div class="tooltip" onclick="elementValueToClipboard('env-test-6-4-raw')">-100.0<textarea style="position: absolute; left: -9999px;"  id="env-test-6-4-raw">{0: &#39;&#39;, &#39;user0&#39;: &#39;&#39;}</textarea>&#x1f527;<span class="tooltiptext">Not present in target results (-100)<br><a href='#'>Test params differ (click to copy raw value):</a><pre>
 0
 =
+-MISSING IN THIS PARAMS
+user0
+=====
 -MISSING IN THIS PARAMS</pre></span></div></td>
-        <td class="status_-2"><div class="tooltip" onclick="elementValueToClipboard('env-test-7-5-raw')">-100.0<textarea style="position: absolute; left: -9999px;"  id="env-test-7-5-raw">{0: &#39;&#39;}</textarea>&#x1f527;<span class="tooltiptext">Not present in target results (-100)<br><a href='#'>Test params differ (click to copy raw value):</a><pre>
+        <td class="status_-2"><div class="tooltip" onclick="elementValueToClipboard('env-test-6-5-raw')">-100.0<textarea style="position: absolute; left: -9999px;"  id="env-test-6-5-raw">{0: &#39;&#39;, &#39;user0&#39;: &#39;&#39;}</textarea>&#x1f527;<span class="tooltiptext">Not present in target results (-100)<br><a href='#'>Test params differ (click to copy raw value):</a><pre>
 0
 =
+-MISSING IN THIS PARAMS
+user0
+=====
 -MISSING IN THIS PARAMS</pre></span></div></td>
     </tr>
     
     <tr class=" status_-2 any_status_-2 any_status_-2 any_status_-2 ">
-        <td class="status_Localhost2/fio/0000:./read-64KiB/throughput/iops_sec.stddev"><div class="tooltip" onclick="elementValueToClipboard('env-test-8-1-raw')">Localhost2/fio/0000:./read-64KiB/throughput/iops_sec.stddev<textarea style="position: absolute; left: -9999px;"  id="env-test-8-1-raw">{0: &#39;benchmark_name:fio\nbs:64k\nclocksource:gettimeofday\ndirect:1\nfilename:/fio\niodepth:32\nioengine:libaio\nlog_avg_msec:1000\nlog_hist_msec:10000\nmax_stddevpct:5\nnumjobs:1\nprimary_metric:iops_sec\nramp_time:5\nruntime:60\nrw:read\nsize:1300000\nsync:0\ntime_based:1\nuid:benchmark_name:%benchmark_name%-controller_host:%controller_host%&#39;}</textarea>&#x1f527;<span class="tooltiptext">Localhost2/fio/0000:./read-64KiB/throughput/iops_sec.stddev<br><a href='#'>Click to copy raw src test params</a></span></div></td>
-        <td class="status_-2"><div class="tooltip" onclick="elementValueToClipboard('env-test-8-2-raw')">-100.0<textarea style="position: absolute; left: -9999px;"  id="env-test-8-2-raw">{0: &#39;&#39;}</textarea>&#x1f527;<span class="tooltiptext">Not present in target results (-100)<br><a href='#'>Test params differ (click to copy raw value):</a><pre>
+        <td class="status_Localhost2/fio/0000:./read-64KiB/throughput/iops_sec.mean"><div class="tooltip" onclick="elementValueToClipboard('env-test-7-1-raw')">Localhost2/fio/0000:./read-64KiB/throughput/iops_sec.mean<textarea style="position: absolute; left: -9999px;"  id="env-test-7-1-raw">{0: &#39;benchmark_name:fio\nbs:64k\nclocksource:gettimeofday\ndirect:1\nfilename:/fio\niodepth:32\nioengine:libaio\nlog_avg_msec:1000\nlog_hist_msec:10000\nmax_stddevpct:5\nnumjobs:1\nprimary_metric:iops_sec\nramp_time:5\nruntime:60\nrw:read\nsize:1300000\nsync:0\ntime_based:1\nuid:benchmark_name:%benchmark_name%-controller_host:%controller_host%&#39;, &#39;user0&#39;: &#39;profile: Localhost&#39;}</textarea>&#x1f527;<span class="tooltiptext">Localhost2/fio/0000:./read-64KiB/throughput/iops_sec.mean<br><a href='#'>Click to copy raw src test params</a></span></div></td>
+        <td class="status_-2"><div class="tooltip" onclick="elementValueToClipboard('env-test-7-2-raw')">-100.0<textarea style="position: absolute; left: -9999px;"  id="env-test-7-2-raw">{0: &#39;&#39;, &#39;user0&#39;: &#39;&#39;}</textarea>&#x1f527;<span class="tooltiptext">Not present in target results (-100)<br><a href='#'>Test params differ (click to copy raw value):</a><pre>
 0
 =
+-MISSING IN THIS PARAMS
+user0
+=====
 -MISSING IN THIS PARAMS</pre></span></div></td>
-        <td class="status_-2"><div class="tooltip" onclick="elementValueToClipboard('env-test-8-3-raw')">-100.0<textarea style="position: absolute; left: -9999px;"  id="env-test-8-3-raw">{0: &#39;&#39;}</textarea>&#x1f527;<span class="tooltiptext">Not present in target results (-100)<br><a href='#'>Test params differ (click to copy raw value):</a><pre>
+        <td class="status_-2"><div class="tooltip" onclick="elementValueToClipboard('env-test-7-3-raw')">-100.0<textarea style="position: absolute; left: -9999px;"  id="env-test-7-3-raw">{0: &#39;&#39;, &#39;user0&#39;: &#39;&#39;}</textarea>&#x1f527;<span class="tooltiptext">Not present in target results (-100)<br><a href='#'>Test params differ (click to copy raw value):</a><pre>
 0
 =
+-MISSING IN THIS PARAMS
+user0
+=====
 -MISSING IN THIS PARAMS</pre></span></div></td>
-        <td class="status_-2"><div class="tooltip" onclick="elementValueToClipboard('env-test-8-4-raw')">-100.0<textarea style="position: absolute; left: -9999px;"  id="env-test-8-4-raw">{0: &#39;&#39;}</textarea>&#x1f527;<span class="tooltiptext">Not present in target results (-100)<br><a href='#'>Test params differ (click to copy raw value):</a><pre>
+        <td class="status_-2"><div class="tooltip" onclick="elementValueToClipboard('env-test-7-4-raw')">-100.0<textarea style="position: absolute; left: -9999px;"  id="env-test-7-4-raw">{0: &#39;&#39;, &#39;user0&#39;: &#39;&#39;}</textarea>&#x1f527;<span class="tooltiptext">Not present in target results (-100)<br><a href='#'>Test params differ (click to copy raw value):</a><pre>
 0
 =
+-MISSING IN THIS PARAMS
+user0
+=====
 -MISSING IN THIS PARAMS</pre></span></div></td>
-        <td class="status_-2"><div class="tooltip" onclick="elementValueToClipboard('env-test-8-5-raw')">-100.0<textarea style="position: absolute; left: -9999px;"  id="env-test-8-5-raw">{0: &#39;&#39;}</textarea>&#x1f527;<span class="tooltiptext">Not present in target results (-100)<br><a href='#'>Test params differ (click to copy raw value):</a><pre>
+        <td class="status_-2"><div class="tooltip" onclick="elementValueToClipboard('env-test-7-5-raw')">-100.0<textarea style="position: absolute; left: -9999px;"  id="env-test-7-5-raw">{0: &#39;&#39;, &#39;user0&#39;: &#39;&#39;}</textarea>&#x1f527;<span class="tooltiptext">Not present in target results (-100)<br><a href='#'>Test params differ (click to copy raw value):</a><pre>
 0
 =
+-MISSING IN THIS PARAMS
+user0
+=====
+-MISSING IN THIS PARAMS</pre></span></div></td>
+    </tr>
+    
+    <tr class=" status_-2 any_status_-2 any_status_-2 any_status_-2 ">
+        <td class="status_Localhost2/fio/0000:./read-64KiB/throughput/iops_sec.stddev"><div class="tooltip" onclick="elementValueToClipboard('env-test-8-1-raw')">Localhost2/fio/0000:./read-64KiB/throughput/iops_sec.stddev<textarea style="position: absolute; left: -9999px;"  id="env-test-8-1-raw">{0: &#39;benchmark_name:fio\nbs:64k\nclocksource:gettimeofday\ndirect:1\nfilename:/fio\niodepth:32\nioengine:libaio\nlog_avg_msec:1000\nlog_hist_msec:10000\nmax_stddevpct:5\nnumjobs:1\nprimary_metric:iops_sec\nramp_time:5\nruntime:60\nrw:read\nsize:1300000\nsync:0\ntime_based:1\nuid:benchmark_name:%benchmark_name%-controller_host:%controller_host%&#39;, &#39;user0&#39;: &#39;profile: Localhost&#39;}</textarea>&#x1f527;<span class="tooltiptext">Localhost2/fio/0000:./read-64KiB/throughput/iops_sec.stddev<br><a href='#'>Click to copy raw src test params</a></span></div></td>
+        <td class="status_-2"><div class="tooltip" onclick="elementValueToClipboard('env-test-8-2-raw')">-100.0<textarea style="position: absolute; left: -9999px;"  id="env-test-8-2-raw">{0: &#39;&#39;, &#39;user0&#39;: &#39;&#39;}</textarea>&#x1f527;<span class="tooltiptext">Not present in target results (-100)<br><a href='#'>Test params differ (click to copy raw value):</a><pre>
+0
+=
+-MISSING IN THIS PARAMS
+user0
+=====
+-MISSING IN THIS PARAMS</pre></span></div></td>
+        <td class="status_-2"><div class="tooltip" onclick="elementValueToClipboard('env-test-8-3-raw')">-100.0<textarea style="position: absolute; left: -9999px;"  id="env-test-8-3-raw">{0: &#39;&#39;, &#39;user0&#39;: &#39;&#39;}</textarea>&#x1f527;<span class="tooltiptext">Not present in target results (-100)<br><a href='#'>Test params differ (click to copy raw value):</a><pre>
+0
+=
+-MISSING IN THIS PARAMS
+user0
+=====
+-MISSING IN THIS PARAMS</pre></span></div></td>
+        <td class="status_-2"><div class="tooltip" onclick="elementValueToClipboard('env-test-8-4-raw')">-100.0<textarea style="position: absolute; left: -9999px;"  id="env-test-8-4-raw">{0: &#39;&#39;, &#39;user0&#39;: &#39;&#39;}</textarea>&#x1f527;<span class="tooltiptext">Not present in target results (-100)<br><a href='#'>Test params differ (click to copy raw value):</a><pre>
+0
+=
+-MISSING IN THIS PARAMS
+user0
+=====
+-MISSING IN THIS PARAMS</pre></span></div></td>
+        <td class="status_-2"><div class="tooltip" onclick="elementValueToClipboard('env-test-8-5-raw')">-100.0<textarea style="position: absolute; left: -9999px;"  id="env-test-8-5-raw">{0: &#39;&#39;, &#39;user0&#39;: &#39;&#39;}</textarea>&#x1f527;<span class="tooltiptext">Not present in target results (-100)<br><a href='#'>Test params differ (click to copy raw value):</a><pre>
+0
+=
+-MISSING IN THIS PARAMS
+user0
+=====
 -MISSING IN THIS PARAMS</pre></span></div></td>
     </tr>
     
@@ -12203,9 +12251,12 @@ NA</pre></span></div></td>
 NA</pre></span></div></td>
         <td class="status_-2"><div class="tooltip" onclick="elementValueToClipboard('env-test-9-3-raw')">NA<textarea style="position: absolute; left: -9999px;"  id="env-test-9-3-raw">NA</textarea>&#x1f527;<span class="tooltiptext">Unknown<br><a href='#'>Test params differ (click to copy raw value):</a><pre>
 NA</pre></span></div></td>
-        <td class="status_-2"><div class="tooltip" onclick="elementValueToClipboard('env-test-9-4-raw')">-100.0<textarea style="position: absolute; left: -9999px;"  id="env-test-9-4-raw">{0: &#39;benchmark_name:fio\nbs:4k\nclocksource:gettimeofday\ndirect:1\nfilename:/fio\niodepth:32\nioengine:libaio\nlog_avg_msec:1000\nlog_hist_msec:10000\nmax_stddevpct:5\nnumjobs:1\nprimary_metric:iops_sec\nramp_time:5\nruntime:60\nrw:read\nsize:1300000\nsync:0\ntime_based:1\nuid:benchmark_name:%benchmark_name%-controller_host:%controller_host%&#39;}</textarea>&#x1f527;<span class="tooltiptext">Not present in source results (145825.271186441).<br><a href='#'>Test params differ (click to copy raw value):</a><pre>
+        <td class="status_-2"><div class="tooltip" onclick="elementValueToClipboard('env-test-9-4-raw')">-100.0<textarea style="position: absolute; left: -9999px;"  id="env-test-9-4-raw">{0: &#39;benchmark_name:fio\nbs:4k\nclocksource:gettimeofday\ndirect:1\nfilename:/fio\niodepth:32\nioengine:libaio\nlog_avg_msec:1000\nlog_hist_msec:10000\nmax_stddevpct:5\nnumjobs:1\nprimary_metric:iops_sec\nramp_time:5\nruntime:60\nrw:read\nsize:1300000\nsync:0\ntime_based:1\nuid:benchmark_name:%benchmark_name%-controller_host:%controller_host%&#39;, &#39;user0&#39;: &#39;profile: Localhost&#39;}</textarea>&#x1f527;<span class="tooltiptext">Not present in source results (145825.271186441).<br><a href='#'>Test params differ (click to copy raw value):</a><pre>
 0
 =
++MISSING IN SRC
+user0
+=====
 +MISSING IN SRC</pre></span></div></td>
         <td class="status_-2"><div class="tooltip" onclick="elementValueToClipboard('env-test-9-5-raw')">NA<textarea style="position: absolute; left: -9999px;"  id="env-test-9-5-raw">NA</textarea>&#x1f527;<span class="tooltiptext">Unknown<br><a href='#'>Test params differ (click to copy raw value):</a><pre>
 NA</pre></span></div></td>
@@ -12218,9 +12269,12 @@ NA</pre></span></div></td>
 NA</pre></span></div></td>
         <td class="status_-2"><div class="tooltip" onclick="elementValueToClipboard('env-test-10-3-raw')">NA<textarea style="position: absolute; left: -9999px;"  id="env-test-10-3-raw">NA</textarea>&#x1f527;<span class="tooltiptext">Unknown<br><a href='#'>Test params differ (click to copy raw value):</a><pre>
 NA</pre></span></div></td>
-        <td class="status_-2"><div class="tooltip" onclick="elementValueToClipboard('env-test-10-4-raw')">-100.0<textarea style="position: absolute; left: -9999px;"  id="env-test-10-4-raw">{0: &#39;benchmark_name:fio\nbs:4k\nclocksource:gettimeofday\ndirect:1\nfilename:/fio\niodepth:32\nioengine:libaio\nlog_avg_msec:1000\nlog_hist_msec:10000\nmax_stddevpct:5\nnumjobs:1\nprimary_metric:iops_sec\nramp_time:5\nruntime:60\nrw:read\nsize:1300000\nsync:0\ntime_based:1\nuid:benchmark_name:%benchmark_name%-controller_host:%controller_host%&#39;}</textarea>&#x1f527;<span class="tooltiptext">Not present in source results (0).<br><a href='#'>Test params differ (click to copy raw value):</a><pre>
+        <td class="status_-2"><div class="tooltip" onclick="elementValueToClipboard('env-test-10-4-raw')">-100.0<textarea style="position: absolute; left: -9999px;"  id="env-test-10-4-raw">{0: &#39;benchmark_name:fio\nbs:4k\nclocksource:gettimeofday\ndirect:1\nfilename:/fio\niodepth:32\nioengine:libaio\nlog_avg_msec:1000\nlog_hist_msec:10000\nmax_stddevpct:5\nnumjobs:1\nprimary_metric:iops_sec\nramp_time:5\nruntime:60\nrw:read\nsize:1300000\nsync:0\ntime_based:1\nuid:benchmark_name:%benchmark_name%-controller_host:%controller_host%&#39;, &#39;user0&#39;: &#39;profile: Localhost&#39;}</textarea>&#x1f527;<span class="tooltiptext">Not present in source results (0).<br><a href='#'>Test params differ (click to copy raw value):</a><pre>
 0
 =
++MISSING IN SRC
+user0
+=====
 +MISSING IN SRC</pre></span></div></td>
         <td class="status_-2"><div class="tooltip" onclick="elementValueToClipboard('env-test-10-5-raw')">NA<textarea style="position: absolute; left: -9999px;"  id="env-test-10-5-raw">NA</textarea>&#x1f527;<span class="tooltiptext">Unknown<br><a href='#'>Test params differ (click to copy raw value):</a><pre>
 NA</pre></span></div></td>
@@ -12233,9 +12287,12 @@ NA</pre></span></div></td>
 NA</pre></span></div></td>
         <td class="status_-2"><div class="tooltip" onclick="elementValueToClipboard('env-test-11-3-raw')">NA<textarea style="position: absolute; left: -9999px;"  id="env-test-11-3-raw">NA</textarea>&#x1f527;<span class="tooltiptext">Unknown<br><a href='#'>Test params differ (click to copy raw value):</a><pre>
 NA</pre></span></div></td>
-        <td class="status_-2"><div class="tooltip" onclick="elementValueToClipboard('env-test-11-4-raw')">-100.0<textarea style="position: absolute; left: -9999px;"  id="env-test-11-4-raw">{0: &#39;benchmark_name:fio\nbs:64k\nclocksource:gettimeofday\ndirect:1\nfilename:/fio\niodepth:32\nioengine:libaio\nlog_avg_msec:1000\nlog_hist_msec:10000\nmax_stddevpct:5\nnumjobs:1\nprimary_metric:iops_sec\nramp_time:5\nruntime:60\nrw:read\nsize:1300000\nsync:0\ntime_based:1\nuid:benchmark_name:%benchmark_name%-controller_host:%controller_host%&#39;}</textarea>&#x1f527;<span class="tooltiptext">Not present in source results (103140.627118644).<br><a href='#'>Test params differ (click to copy raw value):</a><pre>
+        <td class="status_-2"><div class="tooltip" onclick="elementValueToClipboard('env-test-11-4-raw')">-100.0<textarea style="position: absolute; left: -9999px;"  id="env-test-11-4-raw">{0: &#39;benchmark_name:fio\nbs:64k\nclocksource:gettimeofday\ndirect:1\nfilename:/fio\niodepth:32\nioengine:libaio\nlog_avg_msec:1000\nlog_hist_msec:10000\nmax_stddevpct:5\nnumjobs:1\nprimary_metric:iops_sec\nramp_time:5\nruntime:60\nrw:read\nsize:1300000\nsync:0\ntime_based:1\nuid:benchmark_name:%benchmark_name%-controller_host:%controller_host%&#39;, &#39;user0&#39;: &#39;profile: Localhost&#39;}</textarea>&#x1f527;<span class="tooltiptext">Not present in source results (103140.627118644).<br><a href='#'>Test params differ (click to copy raw value):</a><pre>
 0
 =
++MISSING IN SRC
+user0
+=====
 +MISSING IN SRC</pre></span></div></td>
         <td class="status_-2"><div class="tooltip" onclick="elementValueToClipboard('env-test-11-5-raw')">NA<textarea style="position: absolute; left: -9999px;"  id="env-test-11-5-raw">NA</textarea>&#x1f527;<span class="tooltiptext">Unknown<br><a href='#'>Test params differ (click to copy raw value):</a><pre>
 NA</pre></span></div></td>
@@ -12248,9 +12305,12 @@ NA</pre></span></div></td>
 NA</pre></span></div></td>
         <td class="status_-2"><div class="tooltip" onclick="elementValueToClipboard('env-test-12-3-raw')">NA<textarea style="position: absolute; left: -9999px;"  id="env-test-12-3-raw">NA</textarea>&#x1f527;<span class="tooltiptext">Unknown<br><a href='#'>Test params differ (click to copy raw value):</a><pre>
 NA</pre></span></div></td>
-        <td class="status_-2"><div class="tooltip" onclick="elementValueToClipboard('env-test-12-4-raw')">-100.0<textarea style="position: absolute; left: -9999px;"  id="env-test-12-4-raw">{0: &#39;benchmark_name:fio\nbs:64k\nclocksource:gettimeofday\ndirect:1\nfilename:/fio\niodepth:32\nioengine:libaio\nlog_avg_msec:1000\nlog_hist_msec:10000\nmax_stddevpct:5\nnumjobs:1\nprimary_metric:iops_sec\nramp_time:5\nruntime:60\nrw:read\nsize:1300000\nsync:0\ntime_based:1\nuid:benchmark_name:%benchmark_name%-controller_host:%controller_host%&#39;}</textarea>&#x1f527;<span class="tooltiptext">Not present in source results (0).<br><a href='#'>Test params differ (click to copy raw value):</a><pre>
+        <td class="status_-2"><div class="tooltip" onclick="elementValueToClipboard('env-test-12-4-raw')">-100.0<textarea style="position: absolute; left: -9999px;"  id="env-test-12-4-raw">{0: &#39;benchmark_name:fio\nbs:64k\nclocksource:gettimeofday\ndirect:1\nfilename:/fio\niodepth:32\nioengine:libaio\nlog_avg_msec:1000\nlog_hist_msec:10000\nmax_stddevpct:5\nnumjobs:1\nprimary_metric:iops_sec\nramp_time:5\nruntime:60\nrw:read\nsize:1300000\nsync:0\ntime_based:1\nuid:benchmark_name:%benchmark_name%-controller_host:%controller_host%&#39;, &#39;user0&#39;: &#39;profile: Localhost&#39;}</textarea>&#x1f527;<span class="tooltiptext">Not present in source results (0).<br><a href='#'>Test params differ (click to copy raw value):</a><pre>
 0
 =
++MISSING IN SRC
+user0
+=====
 +MISSING IN SRC</pre></span></div></td>
         <td class="status_-2"><div class="tooltip" onclick="elementValueToClipboard('env-test-12-5-raw')">NA<textarea style="position: absolute; left: -9999px;"  id="env-test-12-5-raw">NA</textarea>&#x1f527;<span class="tooltiptext">Unknown<br><a href='#'>Test params differ (click to copy raw value):</a><pre>
 NA</pre></span></div></td>

--- a/runperf/result.py
+++ b/runperf/result.py
@@ -343,6 +343,11 @@ def iter_results(path, skip_incorrect=False):
                 primary_metrics.append(primary_metric)
             test_params[i] = "\n".join("%s:%s" % item
                                        for item in benchmark.items())
+        for i, benchmark in enumerate(data['parameters'].get('user',
+                                                             [])):
+            if "profile" in benchmark:
+                test_params["user%s" % i] = ("profile: %s"
+                                             % benchmark["profile"])
         for workflow in ('throughput', 'latency'):
             workflow_items = data.get(workflow, {}).items()
             for workflow_type, results in workflow_items:


### PR DESCRIPTION
In order to distinguish between potentially different test params we are
using the pbench's "benchmark.parameters[]". Let's add the
"benchmark.user[]" processing to double-check we are using the profile
we thing we are using.

It happened that different results were re-used and in such case this
could improve the detection.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>