### PR TITLE
contrib: Specify avocado module version

### DIFF
--- a/contrib/container/Dockerfile
+++ b/contrib/container/Dockerfile
@@ -5,7 +5,7 @@
 FROM fedora
 MAINTAINER Lukas Doktor ldoktor@redhat.com
 
-RUN dnf -y module enable avocado && dnf install -y python3-pip git python3-pyyaml python3-numpy python3-aexpect python3-jinja2 rsync && dnf clean all
+RUN dnf -y module enable avocado:latest && dnf install -y python3-pip git python3-pyyaml python3-numpy python3-aexpect python3-jinja2 rsync && dnf clean all
 RUN python3 -m pip install git+https://github.com/distributed-system-analysis/run-perf.git
 RUN ssh-keygen -t ed25519 -N "" -f /root/.ssh/id_ed25519
 RUN curl https://raw.githubusercontent.com/distributed-system-analysis/run-perf/master/contrib/bisect.sh > /usr/local/bin/bisect.sh && chmod +x /usr/local/bin/bisect.sh


### PR DESCRIPTION
As the 82 lts module was registered there are multiple matching streams
and we have to specify one. Let's use the latest.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>