### PR TITLE
contrib: Fix build name in upstream_qemu_bisect

### DIFF
--- a/contrib/upstream_qemu_bisect.sh
+++ b/contrib/upstream_qemu_bisect.sh
@@ -106,7 +106,7 @@ chcon -Rt qemu_exec_t /usr/local/bin/qemu-system-"$(uname -m)"
 cp -f build/config.status /usr/local/share/qemu/
 popd
 INNEREOF
-"$BISECT" "$CHECK" "$NAME" "${CMD[@]}"
+"$BISECT" "$CHECK" "${UPSTREAM_QEMU_COMMIT:0:3}" "${CMD[@]}"
 RET=$?
 popd
 exit $RET


### PR DESCRIPTION
The variable NAME does not contains the qemu commit, use the right one
and limit it to only 3 chars (we can get the full hash from the params,
this should be enough for identification purposes).

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>