### PR TITLE
Avoid diffs on kernel cmdline based on a different order

### DIFF
--- a/runperf/machine.py
+++ b/runperf/machine.py
@@ -84,7 +84,10 @@ def get_distro_info(machine):
         out["kernel_raw"] = kernel + '\n' + kernel_cmd
         kernel_cmd = kernel_cmd.replace(kernel_ver, "FILTERED")
         # Sort the kernel_cmdline parts as the order does not matter
-        out["kernel"] = kernel + '\n' + " ".join(sorted(kernel_cmd.split(' ')))
+        out["kernel"] = (kernel + '\n' +
+                         " ".join(sorted(_.strip()
+                                         for _ in kernel_cmd.split(' ')
+                                         if _.strip())))
         out["mitigations"] = session.cmd("grep --color=never . "
                                          "/sys/devices/system/cpu/"
                                          "vulnerabilities/*",

--- a/selftests/core/test_machine.py
+++ b/selftests/core/test_machine.py
@@ -110,10 +110,25 @@ class GetDistroInfo(Selftest):
         self.check(cmd, cmd_status, exp)
 
     def test_order(self):
+        # Check ordering works well including filtering
         self.check(["1.2.3", "c a=1.2.3 b", ""], 1,
                    {'general': 'Name:My Machine\nDistro:My Distro',
                     'kernel': '1.2.3\na=FILTERED b c',
                     'kernel_raw': '1.2.3\nc a=1.2.3 b',
+                    'mitigations': ''})
+        # kernel must be equal for the following 2 commands even though the
+        # last item with \n is different
+        self.check(["1.2.3\nuname -v\nuname -m\n", "a=b c=d\n",
+                    ""], 1,
+                   {'general': 'Name:My Machine\nDistro:My Distro',
+                    'kernel': '1.2.3\nuname -v\nuname -m\n\na=b c=d',
+                    'kernel_raw': '1.2.3\nuname -v\nuname -m\n\na=b c=d\n',
+                    'mitigations': ''})
+        self.check(["1.2.3\nuname -v\nuname -m\n", "c=d a=b\n",
+                    ""], 1,
+                   {'general': 'Name:My Machine\nDistro:My Distro',
+                    'kernel': '1.2.3\nuname -v\nuname -m\n\na=b c=d',
+                    'kernel_raw': '1.2.3\nuname -v\nuname -m\n\nc=d a=b\n',
                     'mitigations': ''})
 
     def test_no_output(self):

--- a/selftests/core/test_machine.py
+++ b/selftests/core/test_machine.py
@@ -102,7 +102,7 @@ class GetDistroInfo(Selftest):
                              "rd.lvm.lv=fedora/root rd.lvm.lv=fedora/swap "
                              "resume=/dev/mapper/fedora-swap ro "
                              "root=/dev/mapper/fedora-root",
-                             'mitigations': VULNERABILITIES,
+               'mitigations': VULNERABILITIES,
                'rpm': 'mc-4.8.24-4.fc32.x86_64\n'}
         kernel, cmdline = exp['kernel_raw'].rsplit('\n', 1)
         cmd = [kernel, cmdline, exp['mitigations'], exp['rpm']]


### PR DESCRIPTION
We are already sorting the items but an extra `strip` is required to avoid diffs based on the last item's `\n`.