### PR TITLE
Add DefaultLibvirtMulti profile and various fixes

### DIFF
--- a/runperf/__init__.py
+++ b/runperf/__init__.py
@@ -31,6 +31,7 @@ import aexpect
 from . import exceptions, tests, result
 from .machine import Controller
 from .version import __version__
+from runperf import utils
 
 PROG = 'run-perf'
 DESCRIPTION = ("A tool to execute the same tasks on pre-defined scenarios/"
@@ -177,6 +178,8 @@ def setup_logging(verbosity_arg, fmt=None):
     # In case root logger already existed reset the root's log_level
     root = logging.getLogger('')
     root.setLevel(log_level)
+    # Store the main log level in utils so MutableShellSession can use it
+    utils.DEFAULT_ROOT_LOG_LEVEL = log_level
 
 
 def create_metadata(output_dir, args):

--- a/runperf/__init__.py
+++ b/runperf/__init__.py
@@ -174,6 +174,9 @@ def setup_logging(verbosity_arg, fmt=None):
 
     logging.basicConfig(level=log_level, stream=sys.stderr,
                         format=fmt, datefmt="%H:%M:%S")
+    # In case root logger already existed reset the root's log_level
+    root = logging.getLogger('')
+    root.setLevel(log_level)
 
 
 def create_metadata(output_dir, args):

--- a/runperf/html_report.py
+++ b/runperf/html_report.py
@@ -213,7 +213,7 @@ def generate_report(path, results, with_charts=False):
             build["distro_short"] = (known_items["distro"]
                                      .get_short(build["distro"]))
             build["runperf_cmd_short"] = (known_items["commands"]
-                                          .get_short("runperf_cmd"))
+                                          .get_short(build["runperf_cmd"]))
             env, profiles = collect_environment(metadata)
             build['profiles'] = profiles
             _build_diff = process_diff_environemnt(env, dst_env)

--- a/runperf/machine.py
+++ b/runperf/machine.py
@@ -660,7 +660,7 @@ class LibvirtGuest(BaseMachine):
         if not self.distro:
             raise ValueError("No distro specified %s" % self.distro)
         lower = self.distro.lower()
-        oss = session.cmd("osinfo-query os -f short-id")
+        oss = session.cmd("osinfo-query os -f short-id", print_func="mute")
         if lower in oss:
             return lower
         if lower.startswith('rhel'):

--- a/runperf/machine.py
+++ b/runperf/machine.py
@@ -25,6 +25,7 @@ import aexpect
 import yaml
 
 from . import exceptions, profiles, utils
+from .utils import MutableShellSession as ShellSession
 
 
 LOG = logging.getLogger(__name__)
@@ -33,39 +34,6 @@ HOSTS_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), 'hosts'))
 # : Minimal set of required keys for host definition
 HOST_KEYS = {'hugepage_kb', 'numa_nodes', 'host_cpus',
              'guest_cpus', 'guest_mem_m', 'arch'}
-
-
-class ShellSession(aexpect.ShellSession):
-    """
-    Mute-able aexpect.ShellSession
-    """
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.__output_func = self.output_func
-        for name in dir(self):
-            if name.startswith('cmd'):
-                func = getattr(self, name)
-                if callable(func):
-                    setattr(self, name, self._muted(func))
-
-    def _muted(self, cmd):
-
-        def inner(*args, **kwargs):
-            if kwargs.get('print_func') == 'mute':
-                kwargs['print_func'] = None
-                logger = logging.getLogger()
-                lvl = logger.getEffectiveLevel()
-                try:
-                    self.set_output_func(None)
-                    logger.setLevel(logging.INFO)
-                    return cmd(*args, **kwargs)
-                finally:
-                    logger.setLevel(lvl)
-                    self.set_output_func(self.__output_func)
-            return cmd(*args, **kwargs)
-
-        return inner
 
 
 # TODO: Move this to `runperf.machine.distro_info` namespace

--- a/runperf/profiles.py
+++ b/runperf/profiles.py
@@ -483,6 +483,37 @@ class DefaultLibvirt(BaseProfile):
         return False
 
 
+class DefaultLibvirtMulti(DefaultLibvirt):
+    """
+    Runs multiple DefaultLibvirt VMS to fill guest_cpus.
+
+    By default it uses 2 CPUs per VM but can be tweaked using
+    `force_guest_cpus` extra parameter.
+    """
+
+    name = "DefaultLibvirtMulti"
+
+    def __init__(self, host, rp_paths, extra):
+        cpus = extra.get("force_guest_cpus")
+        if cpus:
+            cpus = int(cpus)
+        else:
+            cpus = 0
+        if not extra.get("force_no_vms"):
+            # no_vms not specified by user
+            if not cpus:
+                # neither guest_cpus, use 2
+                cpus = 2
+            extra["force_no_vms"] = int(host.params['guest_cpus'] / cpus)
+        elif not cpus:
+            # no_vms specified by user but guest_cpus were not, evaluate it
+            cpus = int(host.params['guest_cpus'] /
+                       int(extra["force_no_vms"]))
+            extra["force_no_vms"] = int(host.params['guest_cpus'] / cpus)
+        extra["force_guest_cpus"] = cpus
+        DefaultLibvirt.__init__(self, host, rp_paths, extra)
+
+
 class Overcommit1p5(DefaultLibvirt):
     """
     CPU host overcommit profile to use 1.5 host cpus using multiple guests

--- a/runperf/profiles.py
+++ b/runperf/profiles.py
@@ -346,24 +346,29 @@ class DefaultLibvirt(BaseProfile):
     name = "DefaultLibvirt"
     img_base = "/var/lib/libvirt/images"
     deps = "libvirt libguestfs-tools-c virt-install"
-    default_password = "redhat"
-    no_vms = 1
 
     def __init__(self, host, rp_paths, extra):
         super().__init__(host, rp_paths, extra)
         self.host = host
-        self.distro = self.host.guest_distro
         self.vms = []
-        self.image = None
         self.shared_pub_key = self.host.shared_pub_key
         self._custom_qemu = self.extra.get("qemu_bin", "")
+        self._guest = {"no_vms": 1,
+                       "guest_cpus": self.host.params["guest_cpus"],
+                       "default_password": "redhat",
+                       "distro": self.host.guest_distro,
+                       "image": None}
+        for param in ("guest_cpus", "guest_mem", "no_vms"):
+            value = self.extra.get("force_" + param)
+            if value:
+                self._guest[param] = value
 
     def _apply(self, setup_script):
         if self.vms:
             raise RuntimeError("VM already defined while applying profile. "
                                "This should never happen!")
         self._prerequisities(self.session)
-        self.image = self._get_image(self.session, setup_script)
+        self._guest["image"] = self._get_image(self.session, setup_script)
         ret = self._start_vms()
         self._set("applied_profile", self.name)
         return ret
@@ -401,8 +406,8 @@ class DefaultLibvirt(BaseProfile):
         entry_point = 'runperf.utils.cloud_image_providers'
         for entry in utils.sorted_entry_points(entry_point):
             klass = entry.load()
-            if klass.is_for(self.distro, self.host.params['arch']):
-                plugin = klass(self.distro, self.host.params['arch'],
+            if klass.is_for(self._guest["distro"], self.host.params['arch']):
+                plugin = klass(self._guest["distro"], self.host.params['arch'],
                                self.shared_pub_key, self.img_base, session,
                                setup_script)
                 out = plugin.is_up_to_date()
@@ -410,32 +415,34 @@ class DefaultLibvirt(BaseProfile):
                     self.log.debug("Reusing existing image")
                     return plugin.image
                 self.log.debug("Fetching %s image using %s because %s",
-                               self.distro, str(plugin), out)
+                               self._guest["distro"], str(plugin), out)
                 for path in plugin.paths:
                     self._path_to_be_removed(path)
-                out = plugin.prepare(self.default_password)
+                out = plugin.prepare(self._guest["default_password"])
                 if out:
-                    self.log.warning("Failed to prepare %s: %s", self.distro,
-                                     out)
+                    self.log.warning("Failed to prepare %s: %s",
+                                     self._guest["distro"], out)
                     continue
-                self.log.debug("Image %s ready", self.distro)
+                self.log.debug("Image %s ready", self._guest["distro"])
                 return plugin.image
         providers = ", ".join(str(_)
                               for _ in pkg_entry_points(entry_point))
         raise RuntimeError("Fail to fetch %s using %s providers"
-                           % (self.distro, providers))
+                           % (self._guest["distro"], providers))
 
     def _start_vms(self):
         from . import machine
-        guest_mem_m = int(self.host.params['guest_mem_m'] / self.no_vms)
-        for i in range(self.no_vms):
+        if not self._guest.get('guest_mem'):
+            self._guest['guest_mem'] = int(self.host.params['guest_mem_m'] /
+                                           self._guest['no_vms'])
+        for i in range(self._guest['no_vms']):
             vm = machine.LibvirtGuest(self.host,
                                       "%s%s" % (self.__class__.__name__, i),
-                                      self.distro,
-                                      self.image,
-                                      self.host.params['guest_cpus'],
-                                      guest_mem_m,
-                                      [self.default_password],
+                                      self._guest["distro"],
+                                      self._guest["image"],
+                                      self._guest['guest_cpus'],
+                                      self._guest['guest_mem'],
+                                      [self._guest["default_password"]],
                                       self.extra)
             self.vms.append(vm)
             vm.start()
@@ -484,9 +491,9 @@ class Overcommit1p5(DefaultLibvirt):
     name = "Overcommit1_5"
 
     def __init__(self, host, rp_paths, extra):
+        extra["force_no_vms"] = int(host.params['host_cpus'] /
+                                    host.params['guest_cpus'] * 1.5)
         super().__init__(host, rp_paths, extra)
-        self.no_vms = int(self.host.params['host_cpus'] /
-                          self.host.params['guest_cpus'] * 1.5)
 
 
 class TunedLibvirt(DefaultLibvirt, PersistentProfile):  # lgtm[py/multiple-calls-to-init]

--- a/selftests/core/test_machine.py
+++ b/selftests/core/test_machine.py
@@ -179,3 +179,7 @@ class LibvirtGuestTests(Selftest):
         self.assertEqual("rhel8.0", vm._get_os_variant(session))
         vm.distro = "NOT-RHEL-8.0"
         self.assertRaises(NotImplementedError, vm._get_os_variant, session)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/selftests/core/test_profiles.py
+++ b/selftests/core/test_profiles.py
@@ -26,7 +26,7 @@ from unittest import mock
 
 from runperf import profiles
 from runperf.machine import Host, ShellSession
-from runperf.profiles import Localhost, DefaultLibvirt
+from runperf.profiles import Localhost, DefaultLibvirt, DefaultLibvirtMulti
 
 from . import Selftest
 
@@ -262,6 +262,18 @@ class DefaultLibvirtTest(Selftest):
         params = {"guest_cpus": 16, "guest_mem_m": 32768}
         self.check(params, {}, 1, 16, 32768)
         self.check(params, {"force_no_vms": 10}, 10, 16, 3276)
+
+    def test_default_libvirt_multi_extra(self):
+        params = {"guest_cpus": 16, "guest_mem_m": 32768}
+        self.check(params, {}, 8, 2, 4096, DefaultLibvirtMulti)
+        self.check(params, {"force_guest_cpus": 3}, 5, 3, 6553,
+                   DefaultLibvirtMulti)
+        self.check(params, {"force_guest_cpus": 3, "force_no_vms": 2}, 2, 3,
+                   16384, DefaultLibvirtMulti)
+        self.check(params, {"force_no_vms": 3}, 3, 5,
+                   10922, DefaultLibvirtMulti)
+        self.check(params, {"force_no_vms": 3, "force_guest_mem": 10}, 3, 5,
+                   10, DefaultLibvirtMulti)
 
 
 if __name__ == '__main__':

--- a/selftests/core/test_profiles.py
+++ b/selftests/core/test_profiles.py
@@ -21,6 +21,7 @@ Tests for the profiles handling
 import argparse
 import os
 import shutil
+import unittest
 from unittest import mock
 
 from runperf import profiles
@@ -226,3 +227,7 @@ class RunPerfTest(Selftest):
                         "rc_local", "persistent_setup_finished",
                         "persistent_setup_expected"):
                 self.assertIn(cmd, str(session.mock_calls))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/selftests/core/test_profiles.py
+++ b/selftests/core/test_profiles.py
@@ -228,6 +228,41 @@ class RunPerfTest(Selftest):
                         "persistent_setup_expected"):
                 self.assertIn(cmd, str(session.mock_calls))
 
+class DefaultLibvirtTest(Selftest):
+    """Check DefaultLibvirt specific handlings"""
+    class FakeGuest:
+        """machine.LibvirtGuest"""
+        def __init__(self, *args, **kwargs):
+            self.args = args
+            self.kwargs = kwargs
+        def start(self):
+            pass
+        def __str__(self):
+            return "%s\n%s" % (self.args, self.kwargs)
+        def __repr__(self):
+            return "%s: %s" % (self.__class__.__name__, str(self))
+        def __eq__(self, other):
+            return self.args == other.args and self.kwargs == other.kwargs
+
+    def check(self, params, extra, vms, cpus, mem, klass=DefaultLibvirt):
+        """
+        Initialize the profile, deploy vms and check they are as expected
+        """
+        host = mock.Mock(shared_pub_key="SSH_PUB_KEY", guest_distro="DISTRO",
+                         params=params)
+        profile = klass(host, "", extra)
+        with mock.patch("runperf.machine.LibvirtGuest", self.FakeGuest):
+            profile._start_vms()
+        self.assertEqual(profile.vms,
+                         [self.FakeGuest(host, klass.name + str(i), 'DISTRO',
+                                         None, cpus, mem, ['redhat'],
+                                         extra) for i in range(vms)])
+
+    def test_default_libvirt_extra(self):
+        params = {"guest_cpus": 16, "guest_mem_m": 32768}
+        self.check(params, {}, 1, 16, 32768)
+        self.check(params, {"force_no_vms": 10}, 10, 16, 3276)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/selftests/core/test_runperf.py
+++ b/selftests/core/test_runperf.py
@@ -19,6 +19,7 @@ Tests for the main runperf app
 import argparse
 import json
 import os
+import unittest
 from unittest import mock
 
 from runperf import main, tests
@@ -167,3 +168,7 @@ class RunPerfTest(Selftest):
                                   ["$@", ["DummyTest", {"foo": "bar"}],
                                    ["DummyTest", {"other": "baz"}], "$@"]},
                                  simple + simple))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/setup.py
+++ b/setup.py
@@ -86,6 +86,7 @@ if __name__ == '__main__':
               'runperf.profiles': [
                   '50Localhost = runperf.profiles:Localhost',
                   '50DefaultLibvirt = runperf.profiles:DefaultLibvirt',
+                  '50DefaultLibvirtMulti = runperf.profiles:DefaultLibvirtMulti',
                   '50Overcommit1_5 = runperf.profiles:Overcommit1p5',
                   '50TunedLibvirt = runperf.profiles:TunedLibvirt'],
               'runperf.tests': [


### PR DESCRIPTION
This PR improves the DefaultLibvirt to allow greater customization and adds a DefaultLibvirtMulti variant which should provide better defaults for multiple smaller symmetrical VMs scenarios.

While working on these there were couple of issues being fixed as well as one parallelization of test.setup was added.