### PR TITLE
Add sync with timeout to avoid laggy machine

### DIFF
--- a/runperf/machine.py
+++ b/runperf/machine.py
@@ -702,6 +702,9 @@ class LibvirtGuest(BaseMachine):
             session.cmd("qemu-img convert -f %s -O %s %s %s"
                         % (src_fmt, fmt, self.base_image, image),
                         timeout=600)
+        # System might get a bit laggy after huge-file copy, use sync to
+        # avoid unresponsive system
+        session.cmd("sync", timeout=600)
         self.image = image
 
         xml = self.extra_params.get("xml", None)


### PR DESCRIPTION
After copying the big file the system might get laggy and following
commands might fail due to short timeouts. Let's force sync with a long
timeout to avoid such issues.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>