### PR TITLE
Copy the "results.json" file instead of using "cat"

### DIFF
--- a/runperf/machine.py
+++ b/runperf/machine.py
@@ -204,6 +204,18 @@ class BaseMachine:
                dst]
         utils.check_output(cmd)
 
+    def copy_to(self, src, dst):
+        """
+        Copy file(s) to the machine
+
+        :warning: This won't check/setup keys
+        """
+        cmd = ["rsync", "-amrh", "-e", "ssh -o StrictHostKeyChecking=no " +
+               "-o UserKnownHostsFile=/dev/null -o ControlMaster=auto " +
+               "-o ControlPath='/var/tmp/%%r@%%h-%%p' -o ControlPersist=60" +
+               " -o BatchMode=yes", src, "root@%s:%s" % (self.get_addr(), dst)]
+        utils.check_output(cmd)
+
     def get_info(self):
         """
         Report basic info about this machine

--- a/runperf/tests.py
+++ b/runperf/tests.py
@@ -92,25 +92,26 @@ class BaseTest:
         meta['workers'] = str_workers
         if session.cmd_status("[ -e '%s' ]" % path) == 0:
             session.cmd("\\cp '%s' '%s.backup'" % (path, path))
-            results = json.loads(session.cmd_output("cat '%s'" % path,
-                                                    timeout=600,
-                                                    print_func='mute'))
-            for result in results:
-                if 'iteration_data' not in result:
-                    continue
-                iteration_data = result['iteration_data']
-                if 'parameters' not in iteration_data:
-                    continue
-                params = iteration_data['parameters']
-                if 'user' in params:
-                    params['user'].append(meta)
-                else:
-                    params['user'] = [meta]
-            results_json = json.dumps(results, indent=4,
-                                      sort_keys=True)
-            session.cmd(utils.shell_write_content_cmd(path,
-                                                      results_json),
-                        timeout=600, print_func='mute')
+            with tempfile.NamedTemporaryFile(prefix="runperf-result",
+                                             suffix=".json") as tmp_file:
+                local_json = tmp_file.name
+                self.host.copy_from(path, local_json)
+                with open(local_json) as fd_local_json:
+                    results = json.load(fd_local_json)
+                for result in results:
+                    if 'iteration_data' not in result:
+                        continue
+                    iteration_data = result['iteration_data']
+                    if 'parameters' not in iteration_data:
+                        continue
+                    params = iteration_data['parameters']
+                    if 'user' in params:
+                        params['user'].append(meta)
+                    else:
+                        params['user'] = [meta]
+                with open(local_json, 'w') as fp_local_json:
+                    json.dump(results, fp_local_json, indent=4, sort_keys=True)
+                self.host.copy_to(local_json, path)
         else:
             dir_path = os.path.dirname(path)
             if session.cmd_status("[ -d '%s' ]" % dir_path) == 0:

--- a/selftests/core/__init__.py
+++ b/selftests/core/__init__.py
@@ -39,6 +39,9 @@ class DummyHost(Host):
     def copy_from(self, src, dst):
         """Do nothing"""
 
+    def copy_to(self, src, dst):
+        """Do nothing"""
+
 
 class Selftest(unittest.TestCase):
     tmpdir = None

--- a/selftests/core/test_runperf.py
+++ b/selftests/core/test_runperf.py
@@ -19,6 +19,7 @@ Tests for the main runperf app
 import argparse
 import json
 import os
+import shutil
 import unittest
 from unittest import mock
 
@@ -101,7 +102,11 @@ class RunPerfTest(Selftest):
             with mock.patch("sys.argv", args):
                 with mock.patch("runperf.machine.BaseMachine.get_ssh_cmd",
                                 lambda *args, **kwargs: "sh"):
-                    main()
+                    with mock.patch("runperf.machine.BaseMachine.copy_from",
+                                    lambda _, src, dst: shutil.copy(src, dst)):
+                        with mock.patch("runperf.machine.BaseMachine.copy_to",
+                                        lambda _, src, dst: shutil.copy(src, dst)):
+                            main()
         # Check only for test dirs, metadata are checked in other tests
         self.assertTrue(os.path.exists(os.path.join(self.tmpdir, "result")))
         for serial in ["0000", "0001"]:


### PR DESCRIPTION
The results files might be quite big and using "cat" is very slow and unreliable. Let's copy the file to our working directory, modify it and push it back.