### PR TITLE
docs.jenkins: Example to fetch the latest kernel from koji

### DIFF
--- a/docs/source/jenkins/jobs.yaml
+++ b/docs/source/jenkins/jobs.yaml
@@ -21,6 +21,7 @@
     param-cmp-stddev-tolerance: 10
     param-cmp-model-job: ''
     param-cmp-model-build: ''
+    param-host-bkr-links: ''
     param-no-reference-builds: 14
     param-fio-nbd-setup: false
     param-upstream-qemu-commit: ''
@@ -88,7 +89,7 @@
         - string:
             name: HOST_BKR_LINKS
             description: 'Space separated list of urls to be grepped for "http.*$arch\\.rpm" and "http.*noarch\\.rpm", filtered by HOST_BKR_LINKS_FILTER and then set to be installed on host/workers with "--allowerase". Intended usage is to use koji/beaker link like: https://koji.fedoraproject.org/koji/buildinfo?buildID=1534744'
-            default: ""
+            default: "{param-host-bkr-links}"
         - string:
             name: HOST_BKR_LINKS_FILTER
             description: 'Filter to be split and applied via "grep -v -e EXPR1 -e EXPR2 ..."'

--- a/docs/source/jenkins/jobs.yaml
+++ b/docs/source/jenkins/jobs.yaml
@@ -117,6 +117,10 @@
             name: UPSTREAM_QEMU_COMMIT
             description: 'Compile and install qemu using provided commit/tag from the upstream git. Use it by using $PROFILE:{{"qemu_bin": "/usr/local/bin/qemu-system-$ARCH"}} when specifying profiles.'
             default: "{param-upstream-qemu-commit}"
+        - bool:
+            name: FEDORA_LATEST_KERNEL
+            description: 'Install the latest kernel from koji (Fedora rpm)'
+            default: false
         - string:
             name: DESCRIPTION_PREFIX
             description: Description prefix (describe the difference from default)

--- a/docs/source/jenkins/runperf.groovy
+++ b/docs/source/jenkins/runperf.groovy
@@ -37,6 +37,8 @@ guestBkrLinksFilter = params.GUEST_BKR_LINKS_FILTER
 fioNbdSetup = params.FIO_NBD_SETUP
 // Add steps to checkout, compile and install the upstream qemu from git
 upstreamQemuCommit = params.UPSTREAM_QEMU_COMMIT
+// Add steps to install the latest kernel from koji (Fedora rpm)
+fedoraLatestKernel = params.FEDORA_LATEST_KERNEL
 // Description prefix (describe the difference from default)
 descriptionPrefix = params.DESCRIPTION_PREFIX
 // Number of reference builds
@@ -61,6 +63,7 @@ thisPath = '.'
 runperfResultsFilter = 'result*/**/*.json,result*/RUNPERF_METADATA'
 makeInstallCmd = '\nmake -j $(getconf _NPROCESSORS_ONLN)\nmake install'
 pythonDeployCmd = 'python3 setup.py develop --user'
+kojiUrl = 'https://koji.fedoraproject.org/koji/'
 
 String getBkrInstallCmd(String hostBkrLinks, String hostBkrLinksFilter, String arch) {
     return ('\nfor url in ' + hostBkrLinks + '; do dnf install -y --allowerasing --skip-broken ' +
@@ -160,6 +163,18 @@ node(workerNode) {
             hostScript += '\nchcon -Rt qemu_exec_t /usr/local/bin/qemu-system-"$(uname -m)"'
             hostScript += '\n\\cp -f build/config.status /usr/local/share/qemu/'
             hostScript += '\ncd $OLD_PWD'
+        }
+        // Install the latest kernel from koji (Fedora rpm)
+        if (fedoraLatestKernel) {
+            kernelBuild = sh(returnStdout: true,
+                             script: ("curl '$kojiUrl/packageinfo?packageID=8' | " +
+                                      'grep -B 4 "complete" | grep "kernel" | ' +
+                                      'grep "git" | grep -m 1 -o -e \'href="[^"]*"\'')
+                             ).trim()[6..-2]
+            kernelBuildUrl = kojiUrl + kernelBuild
+            kernelBuildFilter = 'debug bpftool kernel-tools perf kernel-selftests kernel-doc'
+            hostScript += getBkrInstallCmd(kernelBuildUrl, kernelBuildFilter, arch)
+            guestScript += getBkrInstallCmd(kernelBuildUrl, kernelBuildFilter, arch)
         }
         if (hostScript) {
             writeFile file: 'host_script', text: hostScript

--- a/docs/source/jenkins/runperf.groovy
+++ b/docs/source/jenkins/runperf.groovy
@@ -122,7 +122,7 @@ node(workerNode) {
         }
         // The same on guest
         if (guestBkrLinks) {
-            getBkrInstallCmd(guestBkrLinks, guestBkrLinksFilter, arch)
+            guestScript += getBkrInstallCmd(guestBkrLinks, guestBkrLinksFilter, arch)
         }
         // Install deps and compile custom fio with nbd ioengine
         if (fioNbdSetup) {

--- a/docs/source/jenkins/runperf.groovy
+++ b/docs/source/jenkins/runperf.groovy
@@ -63,7 +63,7 @@ makeInstallCmd = '\nmake -j $(getconf _NPROCESSORS_ONLN)\nmake install'
 pythonDeployCmd = 'python3 setup.py develop --user'
 
 String getBkrInstallCmd(String hostBkrLinks, String hostBkrLinksFilter, String arch) {
-    return ('\nfor url in ' + hostBkrLinks + '; do dnf install -y --allowerasing ' +
+    return ('\nfor url in ' + hostBkrLinks + '; do dnf install -y --allowerasing --skip-broken ' +
             '$(curl -k \$url | grep -o -e "http[^\\"]*' + arch + '\\.rpm" -e ' +
             '"http[^\\"]*noarch\\.rpm" | grep -v $(for expr in ' + hostBkrLinksFilter + '; do ' +
             'echo -n " -e $expr"; done)); done')


### PR DESCRIPTION
There are a couple of fixes and an improvement to the example pipeline which allows to get the latest available kernel-from-git from koji.