### PR TITLE
Mix of little features related to results postprocessing

### DIFF
--- a/runperf/__init__.py
+++ b/runperf/__init__.py
@@ -276,6 +276,11 @@ def main():
         _test_defs = list(tests.get(test, extra) for test, extra in args.tests)
         # provision, fetch assets, ...
         hosts.setup()
+        try:
+            hosts.fetch_logs(os.path.join(args.output, '__sysinfo_before__'))
+        except Exception as exc:
+            utils.record_failure(os.path.join(args.output,
+                                              '__sysinfo_before__'), exc)
         for profile, profile_args in args.profiles:
             # Check whether this profile changes test set
             test_defs = profile_test_defs(profile_args, _test_defs)

--- a/runperf/machine.py
+++ b/runperf/machine.py
@@ -79,6 +79,8 @@ class BaseMachine:
         self.distro = distro  # distribution running/to-be-provisioned
         self.default_passwords = default_passwords  # default ssh passwords
         self.log_fetcher = utils.LogFetcher()
+        # For the first time collect everything
+        self.log_fetcher.params["since"] = 0
 
     def __str__(self):
         return self.name

--- a/runperf/machine.py
+++ b/runperf/machine.py
@@ -798,11 +798,12 @@ class LibvirtGuest(BaseMachine):
             self.xml = True
         else:
             session.cmd("virt-install --import --disk '%s' --memory '%s' "
-                        "--name '%s' --os-variant '%s' --vcpus '%s' "
+                        "--name '%s' --os-variant '%s' --vcpus '%s' --serial "
+                        "file,path=/var/log/libvirt/%s_serial.log "
                         "--dry-run --print-xml > '%s.xml'"
                         % (self.image, self.mem, self.name,
                            self._get_os_variant(session),
-                           self.smp, image))
+                           self.smp, os.path.basename(image), image))
         if "qemu_bin" in self.extra_params:
             session.cmd("echo -e 'cd /domain/devices/emulator\nset %s\nsave' "
                         "| xmllint --shell '%s.xml'"
@@ -868,8 +869,10 @@ class LibvirtGuest(BaseMachine):
                     session.cmd_status("virsh undefine '%s'" % self.name)):
                 errs.append("undefine")
             if self.image:
-                session.cmd_status("rm -f '%s' '%s.xml'"
-                                   % (self.image, self.image))
+                session.cmd_status("rm -f '%s' '%s.xml' '/var/log/libvirt/"
+                                   "%s_serial.log'"
+                                   % (self.image, self.image,
+                                      os.path.basename(self.image)))
             self._started = False
             if errs:
                 raise RuntimeError("Cleanup of %s failed" % errs)

--- a/runperf/profiles.py
+++ b/runperf/profiles.py
@@ -12,6 +12,7 @@
 #
 # Copyright: Red Hat Inc. 2018
 # Author: Lukas Doktor <ldoktor@redhat.com>
+import glob
 import logging
 import os
 import time
@@ -514,6 +515,15 @@ class DefaultLibvirt(BaseProfile):
         if not stat:
             out.append("configuration:\n%s" % config)
         return "\n".join(out)
+
+    def fetch_logs(self, path):
+        BaseProfile.fetch_logs(self, path)
+        for log in glob.glob(os.path.join(path, self.host.get_fullname(),
+                                          'var', 'log', 'libvirt', '*.log')):
+            with open(log) as fd_serial_log:
+                if 'kernel: Call Trace:' in fd_serial_log:
+                    raise("'kernel: Call Trace' found in %s, likely VM "
+                          "had stability issues." % log)
 
     def _revert(self):
         for vm in getattr(self, "vms", []):

--- a/runperf/tests.py
+++ b/runperf/tests.py
@@ -82,7 +82,6 @@ class BaseTest:
         meta = {}
         for key, value in self.metadata.items():
             meta[key] = value
-        meta['cmdline'] = str(sys.argv)
         meta['distro'] = self.host.distro
         meta['profile'] = self.host.profile.name
         str_workers = {}

--- a/runperf/utils/__init__.py
+++ b/runperf/utils/__init__.py
@@ -493,6 +493,9 @@ class LogFetcher:
         for path in paths:
             try:
                 dst = out_path + os.path.sep + path
+                if os.path.exists(dst):
+                    # Avoid fetching the files multiple times
+                    continue
                 try:
                     os.makedirs(os.path.dirname(dst))
                 except FileExistsError:
@@ -516,6 +519,9 @@ class LogFetcher:
                 for cmd in cmds:
                     path = os.path.join(out_path,
                                         string_to_safe_path(cmd))
+                    if os.path.exists(path):
+                        # Avoid fetching the files multiple times
+                        continue
                     try:
                         with open(path, 'w') as out_fd:
                             out_fd.write(session.cmd_output(cmd % self.params,

--- a/selftests/core/test_runperf.py
+++ b/selftests/core/test_runperf.py
@@ -111,16 +111,13 @@ class RunPerfTest(Selftest):
         self.assertTrue(os.path.exists(os.path.join(self.tmpdir, "result")))
         for serial in ["0000", "0001"]:
             result_path = os.path.join(self.tmpdir, "result", "Localhost",
-                                       "DummyTest", serial, "result.json")
+                                       "DummyTest", serial,
+                                       "RUNPERF_METADATA.json")
             self.assertTrue(os.path.exists(result_path))
             with open(result_path) as fd_result:
                 out = json.load(fd_result)
-                self.assertEqual(len(out), 3)
-                for result in out:
-                    user_data = result["iteration_data"]["parameters"]["user"][0]
-                    self.assertIn("profile", user_data)
-                    self.assertIn("workers", user_data)
-                    self.assertIn("cmdline", user_data)
+                self.assertIn("profile", out)
+                self.assertIn("workers", out)
 
     def test_create_metadata(self):
         args = argparse.Namespace(metadata=[], distro=None, guest_distro=None,

--- a/selftests/core/test_tests.py
+++ b/selftests/core/test_tests.py
@@ -75,9 +75,8 @@ class PBenchTest(Selftest):
                         test.run()
                         test.cleanup()
 
-        calls = [exp_cmdline, "[ -e '%s/result.json' ]" % result_path,
-                 "cp '%s/result.json' '%s/result.json.backup'"
-                 % (result_path, result_path)]
+        calls = [exp_cmdline, "[ -d '%s' ]" % result_path,
+                 "cat > %s/RUNPERF_METADATA.json <<" % result_path]
         if "pbench_server_publish" in metadata:
             calls.append('pbench-copy-results --user asdf --prefix fdsa')
         self.check_calls(host.mock_session.method_calls, calls)

--- a/selftests/utils/test_utils.py
+++ b/selftests/utils/test_utils.py
@@ -181,7 +181,8 @@ class LogFetcher(unittest.TestCase):
             self.assertEqual('CONTENT', fd_tmp.read())
         with open(prefix + path3) as fd_tmp:
             self.assertEqual('LAST', fd_tmp.read())
-        with open(prefix + 'COMMANDS/journalctl --no-pager') as fd_tmp:
+        with open(prefix + 'COMMANDS/journalctl --no-pager '
+                  '--since=@%(since)s') as fd_tmp:
             self.assertEqual('OUTPUT', fd_tmp.read())
 
     def test_fail_to_get_session(self):


### PR DESCRIPTION
While analyzing the results I found a few things that should be probably better emphasize, are missing or should not present. This patch series address some of them.

There is one biggish change, which is to stop storing our metadata in the pbench-like format. It generates about 10-30% bigger results while not adding much benefits (apart of having those available in elasticsearch after importing result). Let's only generate our metadata in an extra file, which is attached to the pbench results durin pbench_copy_results anyway.