### PR TITLE
html_report: Add support to produce "small" files

### DIFF
--- a/docs/source/_static/html_result.html
+++ b/docs/source/_static/html_result.html
@@ -11619,7 +11619,6 @@ a {font-family: monospace;}
 
 <div id='summary_table'>
     <table border=1>
-    
     <tr>
         <td>Build</td>
         <td style='background-color: rgba(255, 255.0, 255.0)'><a href="Unknown">1
@@ -11964,7 +11963,6 @@ Localhost2/fio/0000:./read-64KiB/throughput/iops_sec.stddev</pre></span></div></
         <th><a href="Unknown">10
 </a></th>
     </tr>
-    
     <tr class=" status_2 any_status_2 any_status_-1 any_status_2 ">
         <td class="status_*/fio/0000:./read-*/throughput/iops_sec.mean"><div class="tooltip">*/fio/0000:./read-*/throughput/iops_sec.mean<span class="tooltiptext">*/fio/0000:./read-*/throughput/iops_sec.mean</span></div></td>
         <td class="status_2"><div class="tooltip">-6.1<span class="tooltiptext">GOOD raw -6.14% (-6.14; -6.137329747216456) +-10.0% tolerance</span></div></td>
@@ -11972,7 +11970,6 @@ Localhost2/fio/0000:./read-64KiB/throughput/iops_sec.stddev</pre></span></div></
         <td class="status_-1"><div class="tooltip">-10.4<span class="tooltiptext">SMALL raw -10.40% (-10.40; -10.399202130767842) +-10.0% tolerance</span></div></td>
         <td class="status_2"><div class="tooltip">-0.4<span class="tooltiptext">GOOD raw 4.85%, avg -7.63% (4.85; 4.849593176682642) +-10.0% tolerance</span></div></td>
     </tr>
-    
     <tr class=" status_2 any_status_2 any_status_2 any_status_2 ">
         <td class="status_*/fio/0000:./read-*/throughput/iops_sec.stddev"><div class="tooltip">*/fio/0000:./read-*/throughput/iops_sec.stddev<span class="tooltiptext">*/fio/0000:./read-*/throughput/iops_sec.stddev</span></div></td>
         <td class="status_2"><div class="tooltip">0.0<span class="tooltiptext">GOOD raw 0.00% (0.00; 0.0) +-10.0% tolerance</span></div></td>
@@ -11980,7 +11977,6 @@ Localhost2/fio/0000:./read-64KiB/throughput/iops_sec.stddev</pre></span></div></
         <td class="status_2"><div class="tooltip">0.0<span class="tooltiptext">GOOD raw 0.00% (0.00; 0.0) +-10.0% tolerance</span></div></td>
         <td class="status_2"><div class="tooltip">0.0<span class="tooltiptext">GOOD raw 0.00%, avg 0.00% (0.00; 0.0) +-10.0% tolerance</span></div></td>
     </tr>
-    
     <tr class=" status_2 any_status_2 any_status_-1 any_status_2 ">
         <td class="status_Localhost/*/*:./*-*/*/*.mean"><div class="tooltip">Localhost/*/*:./*-*/*/*.mean<span class="tooltiptext">Localhost/*/*:./*-*/*/*.mean</span></div></td>
         <td class="status_2"><div class="tooltip">-6.1<span class="tooltiptext">GOOD raw -6.14% (-6.14; -6.137329747216456) +-10.0% tolerance</span></div></td>
@@ -11988,7 +11984,6 @@ Localhost2/fio/0000:./read-64KiB/throughput/iops_sec.stddev</pre></span></div></
         <td class="status_-1"><div class="tooltip">-10.4<span class="tooltiptext">SMALL raw -10.40% (-10.40; -10.399202130767842) +-10.0% tolerance</span></div></td>
         <td class="status_2"><div class="tooltip">-0.4<span class="tooltiptext">GOOD raw 4.85%, avg -7.63% (4.85; 4.849593176682642) +-10.0% tolerance</span></div></td>
     </tr>
-    
     <tr class=" status_2 any_status_2 any_status_2 any_status_2 ">
         <td class="status_Localhost/*/*:./*-*/*/*.stddev"><div class="tooltip">Localhost/*/*:./*-*/*/*.stddev<span class="tooltiptext">Localhost/*/*:./*-*/*/*.stddev</span></div></td>
         <td class="status_2"><div class="tooltip">0.0<span class="tooltiptext">GOOD raw 0.00% (0.00; 0.0) +-10.0% tolerance</span></div></td>
@@ -11996,7 +11991,6 @@ Localhost2/fio/0000:./read-64KiB/throughput/iops_sec.stddev</pre></span></div></
         <td class="status_2"><div class="tooltip">0.0<span class="tooltiptext">GOOD raw 0.00% (0.00; 0.0) +-10.0% tolerance</span></div></td>
         <td class="status_2"><div class="tooltip">0.0<span class="tooltiptext">GOOD raw 0.00%, avg 0.00% (0.00; 0.0) +-10.0% tolerance</span></div></td>
     </tr>
-    
     <tr class=" status_2 any_status_2 any_status_-1 any_status_2 ">
         <td class="status_Localhost/fio/0000:./read-*/throughput/iops_sec.mean"><div class="tooltip">Localhost/fio/0000:./read-*/throughput/iops_sec.mean<span class="tooltiptext">Localhost/fio/0000:./read-*/throughput/iops_sec.mean</span></div></td>
         <td class="status_2"><div class="tooltip">-6.1<span class="tooltiptext">GOOD raw -6.14% (-6.14; -6.137329747216456) +-10.0% tolerance</span></div></td>
@@ -12004,7 +11998,6 @@ Localhost2/fio/0000:./read-64KiB/throughput/iops_sec.stddev</pre></span></div></
         <td class="status_-1"><div class="tooltip">-10.4<span class="tooltiptext">SMALL raw -10.40% (-10.40; -10.399202130767842) +-10.0% tolerance</span></div></td>
         <td class="status_2"><div class="tooltip">-0.4<span class="tooltiptext">GOOD raw 4.85%, avg -7.63% (4.85; 4.849593176682642) +-10.0% tolerance</span></div></td>
     </tr>
-    
     <tr class=" status_2 any_status_2 any_status_2 any_status_2 ">
         <td class="status_Localhost/fio/0000:./read-*/throughput/iops_sec.stddev"><div class="tooltip">Localhost/fio/0000:./read-*/throughput/iops_sec.stddev<span class="tooltiptext">Localhost/fio/0000:./read-*/throughput/iops_sec.stddev</span></div></td>
         <td class="status_2"><div class="tooltip">0.0<span class="tooltiptext">GOOD raw 0.00% (0.00; 0.0) +-10.0% tolerance</span></div></td>
@@ -12067,7 +12060,6 @@ Localhost2/fio/0000:./read-64KiB/throughput/iops_sec.stddev</pre></span></div></
         <th><a href="Unknown">10
 </a></th>
     </tr>
-    
     <tr class=" status_-1 any_status_-1 any_status_-1 any_status_-1 ">
         <td class="status_Localhost/fio/0000:./read-4KiB/throughput/iops_sec.mean"><div class="tooltip" onclick="elementValueToClipboard('env-test-1-1-raw')">Localhost/fio/0000:./read-4KiB/throughput/iops_sec.mean<textarea style="position: absolute; left: -9999px;"  id="env-test-1-1-raw">{0: &#39;benchmark_name:fio\nbs:4k\nclocksource:gettimeofday\ndirect:1\nfilename:/fio\niodepth:32\nioengine:libaio\nlog_avg_msec:1000\nlog_hist_msec:10000\nmax_stddevpct:5\nnumjobs:1\nprimary_metric:iops_sec\nramp_time:5\nruntime:60\nrw:read\nsize:1300000\nsync:0\ntime_based:1\nuid:benchmark_name:%benchmark_name%-controller_host:%controller_host%&#39;, &#39;user0&#39;: &#39;profile: Localhost&#39;}</textarea>&#x1f527;<span class="tooltiptext">Localhost/fio/0000:./read-4KiB/throughput/iops_sec.mean<br><a href='#'>Click to copy raw src test params</a></span></div></td>
         <td class="status_2"><div class="tooltip" onclick="elementValueToClipboard('env-test-1-2-raw')">-1.3<span class="tooltiptext">GOOD model0 -1.26%, mraw0 -1.21%, raw -3.57% (179348.46/183743.17; 177181.152542373) +-5.0% tolerance</span></div></td>
@@ -12079,7 +12071,6 @@ Localhost2/fio/0000:./read-64KiB/throughput/iops_sec.stddev</pre></span></div></
 -runtime:60
 +runtime:61</pre></span></div></td>
     </tr>
-    
     <tr class=" status_2 any_status_2 any_status_2 any_status_2 ">
         <td class="status_Localhost/fio/0000:./read-4KiB/throughput/iops_sec.stddev"><div class="tooltip" onclick="elementValueToClipboard('env-test-2-1-raw')">Localhost/fio/0000:./read-4KiB/throughput/iops_sec.stddev<textarea style="position: absolute; left: -9999px;"  id="env-test-2-1-raw">{0: &#39;benchmark_name:fio\nbs:4k\nclocksource:gettimeofday\ndirect:1\nfilename:/fio\niodepth:32\nioengine:libaio\nlog_avg_msec:1000\nlog_hist_msec:10000\nmax_stddevpct:5\nnumjobs:1\nprimary_metric:iops_sec\nramp_time:5\nruntime:60\nrw:read\nsize:1300000\nsync:0\ntime_based:1\nuid:benchmark_name:%benchmark_name%-controller_host:%controller_host%&#39;, &#39;user0&#39;: &#39;profile: Localhost&#39;}</textarea>&#x1f527;<span class="tooltiptext">Localhost/fio/0000:./read-4KiB/throughput/iops_sec.stddev<br><a href='#'>Click to copy raw src test params</a></span></div></td>
         <td class="status_2"><div class="tooltip" onclick="elementValueToClipboard('env-test-2-2-raw')">0.0<span class="tooltiptext">GOOD raw 0.00% (0; 0) +-10.0% tolerance</span></div></td>
@@ -12091,7 +12082,6 @@ Localhost2/fio/0000:./read-64KiB/throughput/iops_sec.stddev</pre></span></div></
 -runtime:60
 +runtime:61</pre></span></div></td>
     </tr>
-    
     <tr class=" status_-3 any_status_1 any_status_1 any_status_-3 ">
         <td class="status_Localhost/fio/0000:./read-64KiB/throughput/iops_sec.mean"><div class="tooltip" onclick="elementValueToClipboard('env-test-3-1-raw')">Localhost/fio/0000:./read-64KiB/throughput/iops_sec.mean<textarea style="position: absolute; left: -9999px;"  id="env-test-3-1-raw">{0: &#39;benchmark_name:fio\nbs:64k\nclocksource:gettimeofday\ndirect:1\nfilename:/fio\niodepth:32\nioengine:libaio\nlog_avg_msec:1000\nlog_hist_msec:10000\nmax_stddevpct:5\nnumjobs:1\nprimary_metric:iops_sec\nramp_time:5\nruntime:60\nrw:read\nsize:1300000\nsync:0\ntime_based:1\nuid:benchmark_name:%benchmark_name%-controller_host:%controller_host%&#39;, &#39;user0&#39;: &#39;profile: Localhost&#39;}</textarea>&#x1f527;<span class="tooltiptext">Localhost/fio/0000:./read-64KiB/throughput/iops_sec.mean<br><a href='#'>Click to copy raw src test params</a></span></div></td>
         <td class="status_-1"><div class="tooltip" onclick="elementValueToClipboard('env-test-3-2-raw')">-6.8<span class="tooltiptext">SMALL model0 -6.75%, mraw0 -6.14%, raw -8.70% (100482.88/103308.03; 94316.7627118644) +-5.0% tolerance</span></div></td>
@@ -12103,7 +12093,6 @@ Localhost2/fio/0000:./read-64KiB/throughput/iops_sec.stddev</pre></span></div></
 -runtime:60
 +runtime:61</pre></span></div></td>
     </tr>
-    
     <tr class=" status_2 any_status_2 any_status_2 any_status_2 ">
         <td class="status_Localhost/fio/0000:./read-64KiB/throughput/iops_sec.stddev"><div class="tooltip" onclick="elementValueToClipboard('env-test-4-1-raw')">Localhost/fio/0000:./read-64KiB/throughput/iops_sec.stddev<textarea style="position: absolute; left: -9999px;"  id="env-test-4-1-raw">{0: &#39;benchmark_name:fio\nbs:64k\nclocksource:gettimeofday\ndirect:1\nfilename:/fio\niodepth:32\nioengine:libaio\nlog_avg_msec:1000\nlog_hist_msec:10000\nmax_stddevpct:5\nnumjobs:1\nprimary_metric:iops_sec\nramp_time:5\nruntime:60\nrw:read\nsize:1300000\nsync:0\ntime_based:1\nuid:benchmark_name:%benchmark_name%-controller_host:%controller_host%&#39;, &#39;user0&#39;: &#39;profile: Localhost&#39;}</textarea>&#x1f527;<span class="tooltiptext">Localhost/fio/0000:./read-64KiB/throughput/iops_sec.stddev<br><a href='#'>Click to copy raw src test params</a></span></div></td>
         <td class="status_2"><div class="tooltip" onclick="elementValueToClipboard('env-test-4-2-raw')">0.0<span class="tooltiptext">GOOD raw 0.00% (0; 0) +-10.0% tolerance</span></div></td>
@@ -12115,7 +12104,6 @@ Localhost2/fio/0000:./read-64KiB/throughput/iops_sec.stddev</pre></span></div></
 -runtime:60
 +runtime:61</pre></span></div></td>
     </tr>
-    
     <tr class=" status_-2 any_status_-2 any_status_-2 any_status_-2 ">
         <td class="status_Localhost2/fio/0000:./read-4KiB/throughput/iops_sec.mean"><div class="tooltip" onclick="elementValueToClipboard('env-test-5-1-raw')">Localhost2/fio/0000:./read-4KiB/throughput/iops_sec.mean<textarea style="position: absolute; left: -9999px;"  id="env-test-5-1-raw">{0: &#39;benchmark_name:fio\nbs:4k\nclocksource:gettimeofday\ndirect:1\nfilename:/fio\niodepth:32\nioengine:libaio\nlog_avg_msec:1000\nlog_hist_msec:10000\nmax_stddevpct:5\nnumjobs:1\nprimary_metric:iops_sec\nramp_time:5\nruntime:60\nrw:read\nsize:1300000\nsync:0\ntime_based:1\nuid:benchmark_name:%benchmark_name%-controller_host:%controller_host%&#39;, &#39;user0&#39;: &#39;profile: Localhost&#39;}</textarea>&#x1f527;<span class="tooltiptext">Localhost2/fio/0000:./read-4KiB/throughput/iops_sec.mean<br><a href='#'>Click to copy raw src test params</a></span></div></td>
         <td class="status_-2"><div class="tooltip" onclick="elementValueToClipboard('env-test-5-2-raw')">-100.0<textarea style="position: absolute; left: -9999px;"  id="env-test-5-2-raw">{0: &#39;&#39;, &#39;user0&#39;: &#39;&#39;}</textarea>&#x1f527;<span class="tooltiptext">Not present in target results (-100)<br><a href='#'>Test params differ (click to copy raw value):</a><pre>
@@ -12147,7 +12135,6 @@ user0
 =====
 -MISSING IN THIS PARAMS</pre></span></div></td>
     </tr>
-    
     <tr class=" status_-2 any_status_-2 any_status_-2 any_status_-2 ">
         <td class="status_Localhost2/fio/0000:./read-4KiB/throughput/iops_sec.stddev"><div class="tooltip" onclick="elementValueToClipboard('env-test-6-1-raw')">Localhost2/fio/0000:./read-4KiB/throughput/iops_sec.stddev<textarea style="position: absolute; left: -9999px;"  id="env-test-6-1-raw">{0: &#39;benchmark_name:fio\nbs:4k\nclocksource:gettimeofday\ndirect:1\nfilename:/fio\niodepth:32\nioengine:libaio\nlog_avg_msec:1000\nlog_hist_msec:10000\nmax_stddevpct:5\nnumjobs:1\nprimary_metric:iops_sec\nramp_time:5\nruntime:60\nrw:read\nsize:1300000\nsync:0\ntime_based:1\nuid:benchmark_name:%benchmark_name%-controller_host:%controller_host%&#39;, &#39;user0&#39;: &#39;profile: Localhost&#39;}</textarea>&#x1f527;<span class="tooltiptext">Localhost2/fio/0000:./read-4KiB/throughput/iops_sec.stddev<br><a href='#'>Click to copy raw src test params</a></span></div></td>
         <td class="status_-2"><div class="tooltip" onclick="elementValueToClipboard('env-test-6-2-raw')">-100.0<textarea style="position: absolute; left: -9999px;"  id="env-test-6-2-raw">{0: &#39;&#39;, &#39;user0&#39;: &#39;&#39;}</textarea>&#x1f527;<span class="tooltiptext">Not present in target results (-100)<br><a href='#'>Test params differ (click to copy raw value):</a><pre>
@@ -12179,7 +12166,6 @@ user0
 =====
 -MISSING IN THIS PARAMS</pre></span></div></td>
     </tr>
-    
     <tr class=" status_-2 any_status_-2 any_status_-2 any_status_-2 ">
         <td class="status_Localhost2/fio/0000:./read-64KiB/throughput/iops_sec.mean"><div class="tooltip" onclick="elementValueToClipboard('env-test-7-1-raw')">Localhost2/fio/0000:./read-64KiB/throughput/iops_sec.mean<textarea style="position: absolute; left: -9999px;"  id="env-test-7-1-raw">{0: &#39;benchmark_name:fio\nbs:64k\nclocksource:gettimeofday\ndirect:1\nfilename:/fio\niodepth:32\nioengine:libaio\nlog_avg_msec:1000\nlog_hist_msec:10000\nmax_stddevpct:5\nnumjobs:1\nprimary_metric:iops_sec\nramp_time:5\nruntime:60\nrw:read\nsize:1300000\nsync:0\ntime_based:1\nuid:benchmark_name:%benchmark_name%-controller_host:%controller_host%&#39;, &#39;user0&#39;: &#39;profile: Localhost&#39;}</textarea>&#x1f527;<span class="tooltiptext">Localhost2/fio/0000:./read-64KiB/throughput/iops_sec.mean<br><a href='#'>Click to copy raw src test params</a></span></div></td>
         <td class="status_-2"><div class="tooltip" onclick="elementValueToClipboard('env-test-7-2-raw')">-100.0<textarea style="position: absolute; left: -9999px;"  id="env-test-7-2-raw">{0: &#39;&#39;, &#39;user0&#39;: &#39;&#39;}</textarea>&#x1f527;<span class="tooltiptext">Not present in target results (-100)<br><a href='#'>Test params differ (click to copy raw value):</a><pre>
@@ -12211,7 +12197,6 @@ user0
 =====
 -MISSING IN THIS PARAMS</pre></span></div></td>
     </tr>
-    
     <tr class=" status_-2 any_status_-2 any_status_-2 any_status_-2 ">
         <td class="status_Localhost2/fio/0000:./read-64KiB/throughput/iops_sec.stddev"><div class="tooltip" onclick="elementValueToClipboard('env-test-8-1-raw')">Localhost2/fio/0000:./read-64KiB/throughput/iops_sec.stddev<textarea style="position: absolute; left: -9999px;"  id="env-test-8-1-raw">{0: &#39;benchmark_name:fio\nbs:64k\nclocksource:gettimeofday\ndirect:1\nfilename:/fio\niodepth:32\nioengine:libaio\nlog_avg_msec:1000\nlog_hist_msec:10000\nmax_stddevpct:5\nnumjobs:1\nprimary_metric:iops_sec\nramp_time:5\nruntime:60\nrw:read\nsize:1300000\nsync:0\ntime_based:1\nuid:benchmark_name:%benchmark_name%-controller_host:%controller_host%&#39;, &#39;user0&#39;: &#39;profile: Localhost&#39;}</textarea>&#x1f527;<span class="tooltiptext">Localhost2/fio/0000:./read-64KiB/throughput/iops_sec.stddev<br><a href='#'>Click to copy raw src test params</a></span></div></td>
         <td class="status_-2"><div class="tooltip" onclick="elementValueToClipboard('env-test-8-2-raw')">-100.0<textarea style="position: absolute; left: -9999px;"  id="env-test-8-2-raw">{0: &#39;&#39;, &#39;user0&#39;: &#39;&#39;}</textarea>&#x1f527;<span class="tooltiptext">Not present in target results (-100)<br><a href='#'>Test params differ (click to copy raw value):</a><pre>
@@ -12243,7 +12228,6 @@ user0
 =====
 -MISSING IN THIS PARAMS</pre></span></div></td>
     </tr>
-    
     <tr class=" status_-2 any_status_-2 any_status_-2 any_status_-2 ">
         <td class="status_Localhost3/fio/0000:./read-4KiB/throughput/iops_sec.mean"><div class="tooltip" onclick="elementValueToClipboard('env-test-9-1-raw')">Localhost3/fio/0000:./read-4KiB/throughput/iops_sec.mean<textarea style="position: absolute; left: -9999px;"  id="env-test-9-1-raw">NA</textarea>&#x1f527;<span class="tooltiptext">Localhost3/fio/0000:./read-4KiB/throughput/iops_sec.mean<br><a href='#'>Test params differ (click to copy raw value):</a><pre>
 NA</pre></span></div></td>
@@ -12261,7 +12245,6 @@ user0
         <td class="status_-2"><div class="tooltip" onclick="elementValueToClipboard('env-test-9-5-raw')">NA<textarea style="position: absolute; left: -9999px;"  id="env-test-9-5-raw">NA</textarea>&#x1f527;<span class="tooltiptext">Unknown<br><a href='#'>Test params differ (click to copy raw value):</a><pre>
 NA</pre></span></div></td>
     </tr>
-    
     <tr class=" status_-2 any_status_-2 any_status_-2 any_status_-2 ">
         <td class="status_Localhost3/fio/0000:./read-4KiB/throughput/iops_sec.stddev"><div class="tooltip" onclick="elementValueToClipboard('env-test-10-1-raw')">Localhost3/fio/0000:./read-4KiB/throughput/iops_sec.stddev<textarea style="position: absolute; left: -9999px;"  id="env-test-10-1-raw">NA</textarea>&#x1f527;<span class="tooltiptext">Localhost3/fio/0000:./read-4KiB/throughput/iops_sec.stddev<br><a href='#'>Test params differ (click to copy raw value):</a><pre>
 NA</pre></span></div></td>
@@ -12279,7 +12262,6 @@ user0
         <td class="status_-2"><div class="tooltip" onclick="elementValueToClipboard('env-test-10-5-raw')">NA<textarea style="position: absolute; left: -9999px;"  id="env-test-10-5-raw">NA</textarea>&#x1f527;<span class="tooltiptext">Unknown<br><a href='#'>Test params differ (click to copy raw value):</a><pre>
 NA</pre></span></div></td>
     </tr>
-    
     <tr class=" status_-2 any_status_-2 any_status_-2 any_status_-2 ">
         <td class="status_Localhost3/fio/0000:./read-64KiB/throughput/iops_sec.mean"><div class="tooltip" onclick="elementValueToClipboard('env-test-11-1-raw')">Localhost3/fio/0000:./read-64KiB/throughput/iops_sec.mean<textarea style="position: absolute; left: -9999px;"  id="env-test-11-1-raw">NA</textarea>&#x1f527;<span class="tooltiptext">Localhost3/fio/0000:./read-64KiB/throughput/iops_sec.mean<br><a href='#'>Test params differ (click to copy raw value):</a><pre>
 NA</pre></span></div></td>
@@ -12297,7 +12279,6 @@ user0
         <td class="status_-2"><div class="tooltip" onclick="elementValueToClipboard('env-test-11-5-raw')">NA<textarea style="position: absolute; left: -9999px;"  id="env-test-11-5-raw">NA</textarea>&#x1f527;<span class="tooltiptext">Unknown<br><a href='#'>Test params differ (click to copy raw value):</a><pre>
 NA</pre></span></div></td>
     </tr>
-    
     <tr class=" status_-2 any_status_-2 any_status_-2 any_status_-2 ">
         <td class="status_Localhost3/fio/0000:./read-64KiB/throughput/iops_sec.stddev"><div class="tooltip" onclick="elementValueToClipboard('env-test-12-1-raw')">Localhost3/fio/0000:./read-64KiB/throughput/iops_sec.stddev<textarea style="position: absolute; left: -9999px;"  id="env-test-12-1-raw">NA</textarea>&#x1f527;<span class="tooltiptext">Localhost3/fio/0000:./read-64KiB/throughput/iops_sec.stddev<br><a href='#'>Test params differ (click to copy raw value):</a><pre>
 NA</pre></span></div></td>

--- a/runperf/__init__.py
+++ b/runperf/__init__.py
@@ -405,6 +405,9 @@ class ComparePerf:
                             "in the provided path.")
         parser.add_argument("--html-with-charts", action="store_true",
                             help="Generate charts in the html results")
+        parser.add_argument("--html-small-file", help="Do not include the "
+                            "full environments and such to minimize the report"
+                            "size.", action="store_true")
         parser.add_argument("--xunit", help="Write XUnit/JUnit results to "
                             "specified file.")
         parser.add_argument("--verbose", "-v", action="count", default=0,
@@ -437,7 +440,8 @@ class ComparePerf:
             from . import html_report  # pylint: disable=C0415
             self.log.debug("Generating HTML report: %s", args.html)
             html_report.generate_report(args.html, results,
-                                        args.html_with_charts)
+                                        args.html_with_charts,
+                                        args.html_small_file)
         return res.finish()
 
 

--- a/runperf/assets/html_report/report_template.html
+++ b/runperf/assets/html_report/report_template.html
@@ -10513,7 +10513,7 @@ a {font-family: monospace;}
 
 <div id='summary_table'>
     <table border=1>
-    {% macro relative_score_color(build) %}background-color: rgba(255, {{255 - (build.relative_score * 255 / builds.__len__())}}, {{255 - (build.relative_score * 255 / builds.__len__())}}){% endmacro %}
+    {%- macro relative_score_color(build) %}background-color: rgba(255, {{255 - (build.relative_score * 255 / builds.__len__())}}, {{255 - (build.relative_score * 255 / builds.__len__())}}){% endmacro %}
     <tr>
         <td>Build</td>{% for build in builds %}
         <td style='{{ relative_score_color(build) }}'><a href="{{build.url}}">{{build.build}}</a></td>{% endfor %}
@@ -10604,7 +10604,7 @@ a {font-family: monospace;}
         <th>Test</th>{% for build in builds %}{% if loop.index != 1 %}
         <th><a href="{{build.url}}">{{build.build}}</a></th>{% endif %}{% endfor %}
     </tr>{% for builds_status in group_statuses %}{% set tests_loop = loop %}
-    {# FIXME: Bring unique back; probably using [] and append #}
+    {# FIXME: Bring unique back; probably using [] and append -#}
     <tr class=" status_{{builds_status[-1][0]}} {% for status, _, _ in builds_status %}{% if loop.index > 2 %}any_status_{{status}} {% endif %}{% endfor %}">{% for status, details, score in builds_status %}
         <td class="status_{{status}}"><div class="tooltip">{{score}}<span class="tooltiptext">{{details}}</span></div></td>{% endfor %}
     </tr>{% endfor %}
@@ -10648,7 +10648,7 @@ a {font-family: monospace;}
         <th>Test</th>{% for build in builds %}{% if loop.index != 1 %}
         <th><a href="{{build.url}}">{{build.build}}</a></th>{% endif %}{% endfor %}
     </tr>{% for builds_status in builds_statuses %}{% set tests_loop = loop %}
-    {# FIXME: Bring unique back; probably using [] and append #}
+    {#- FIXME: Bring unique back; probably using [] and append #}
     <tr class=" status_{{builds_status[-1][0]}} {% for status, _, _, _ in builds_status %}{% if loop.index > 2 %}any_status_{{status}} {% endif %}{% endfor %}">{% for status, details, score, params in builds_status %}
         <td class="status_{{status}}"><div class="tooltip" onclick="elementValueToClipboard('env-test-{{tests_loop.index}}-{{loop.index}}-raw')">{{score}}{% if params[1] or (loop.index == 1 and params[0]) %}<textarea style="position: absolute; left: -9999px;"  id="env-test-{{tests_loop.index}}-{{loop.index}}-raw">{{params[0]}}</textarea>&#x1f527;{% endif %}<span class="tooltiptext">{{details}}{% if params[1] %}<br><a href='#'>Test params differ (click to copy raw value):</a><pre>
 {{params[1]}}</pre>{% elif loop.index == 1 and params[0] %}<br><a href='#'>Click to copy raw src test params</a>{% endif %}</span></div></td>{% endfor %}


### PR DESCRIPTION
The html_report is usually quite verbose, containing the full environments and such. Let's add a "--html-small-file" argument to remove those in order to minimize the html report size. This is useful when one already packs the metadata to the results.