### PR TITLE
Update pbench-devel.repo

### DIFF
--- a/runperf/assets/pbench-devel.repo
+++ b/runperf/assets/pbench-devel.repo
@@ -1,9 +1,10 @@
-[copr-pbench]
-name=Copr repo for pbench
-baseurl=https://copr-be.cloud.fedoraproject.org/results/ndokos/pbench/%s-$releasever-$basearch/
+[copr:copr.fedorainfracloud.org:portante:pbench]
+name=Copr repo for pbench owned by portante
+baseurl=https://download.copr.fedorainfracloud.org/results/portante/pbench/%s-$releasever-$basearch/
+type=rpm-md
 skip_if_unavailable=True
-gpgcheck= 1
-gpgkey=https://copr-be.cloud.fedoraproject.org/results/ndokos/pbench/pubkey.gpg
+gpgcheck=1
+gpgkey=https://download.copr.fedorainfracloud.org/results/portante/pbench/pubkey.gpg
+repo_gpgcheck=0
 enabled=1
 enabled_metadata=1
-skip_if_unavailable=1


### PR DESCRIPTION
The active pbench repo moved from ndokos to pportante.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>