### PR TITLE
pbench: Always include the el8 ndokos repo

### DIFF
--- a/runperf/assets/pbench-devel.repo
+++ b/runperf/assets/pbench-devel.repo
@@ -8,3 +8,14 @@ gpgkey=https://download.copr.fedorainfracloud.org/results/portante/pbench/pubkey
 repo_gpgcheck=0
 enabled=1
 enabled_metadata=1
+
+[copr-pbench-ndokos-el8]
+# Inject el8 repo as it contains the pbench-$test builds
+name=Copr repo for pbench
+baseurl=https://copr-be.cloud.fedoraproject.org/results/ndokos/pbench/epel-8-$basearch/
+skip_if_unavailable=True
+gpgcheck= 1
+gpgkey=https://copr-be.cloud.fedoraproject.org/results/ndokos/pbench/pubkey.gpg
+enabled=1
+enabled_metadata=1
+skip_if_unavailable=1


### PR DESCRIPTION
The other repos or even other releases do not contain the pbench-$test
builds. Let's always include this fairly outdated repo and rely on dnf
to install the latest and most suitable rpms.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>