### PR TITLE
LibvirtGuest fixes to allow booting Fedora

### DIFF
--- a/runperf/machine.py
+++ b/runperf/machine.py
@@ -799,11 +799,13 @@ class LibvirtGuest(BaseMachine):
         else:
             session.cmd("virt-install --import --disk '%s' --memory '%s' "
                         "--name '%s' --os-variant '%s' --vcpus '%s' --serial "
-                        "file,path=/var/log/libvirt/%s_serial.log "
+                        "file,path=/var/log/libvirt/%s_serial.log %s "
                         "--dry-run --print-xml > '%s.xml'"
                         % (self.image, self.mem, self.name,
-                           self._get_os_variant(session),
-                           self.smp, os.path.basename(image), image))
+                           self._get_os_variant(session), self.smp,
+                           os.path.basename(image),
+                           self.extra_params.get('virt-install-extra', ''),
+                           image))
         if "qemu_bin" in self.extra_params:
             session.cmd("echo -e 'cd /domain/devices/emulator\nset %s\nsave' "
                         "| xmllint --shell '%s.xml'"

--- a/runperf/utils/cloud_image_providers.py
+++ b/runperf/utils/cloud_image_providers.py
@@ -155,7 +155,8 @@ class Fedora(BaseProvider):
             return False
 
     def _extend_cloudinit_cmd(self, cmd):
+        # Currently Fedora fails to boot when "--update" is specified
+        # (initrd rebuild changes disk uuid)
         cmd += (" --run-command 'yum -y remove cloud-init "
-                "cloud-utils-growpart || true' --selinux-relabel "
-                "--update")
+                "cloud-utils-growpart || true' --selinux-relabel")
         return cmd


### PR DESCRIPTION
The current Fedora 34 is not bootable with "--update" executed in virt-customize, let's remove it but allow to manually extend the virt-customize.