### PR TITLE
utils.pbench: Attempt to install python3-libselinux

### DIFF
--- a/runperf/utils/pbench.py
+++ b/runperf/utils/pbench.py
@@ -92,8 +92,8 @@ class Dnf:  # pylint: disable=R0903
                                "assets", "pbench-devel.repo")) as repo:
             session.cmd(shell_write_content_cmd("/etc/yum.repos.d/pbench-devel."
                                                 "repo", repo.read() % distro))
-        session.cmd("dnf install -y --nobest pbench-agent "
-                    "pbench-sysstat", timeout=600)
+        session.cmd("dnf install -y --nobest --skip-broken pbench-agent "
+                    "pbench-sysstat python3-libselinux", timeout=600)
         self._update_pbench()
 
     def _check_test_installed(self):


### PR DESCRIPTION
The python3-libselinux is required for pbench to run when selinux is
enabled. Let's add it along with --skip-broken so it doesn't need to be
installed when unavailable.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>