### PR TITLE
Fix rsync command

### DIFF
--- a/runperf/machine.py
+++ b/runperf/machine.py
@@ -208,7 +208,7 @@ class BaseMachine:
         """
         cmd = ["rsync", "-amrh", "-e", "ssh -o StrictHostKeyChecking=no " +
                "-o UserKnownHostsFile=/dev/null -o ControlMaster=auto " +
-               "-o ControlPath='/var/tmp/%%r@%%h-%%p' -o ControlPersist=60" +
+               "-o ControlPath='/var/tmp/%r@%h-%p' -o ControlPersist=60" +
                " -o BatchMode=yes", "root@%s:%s" % (self.get_addr(), src),
                dst]
         utils.check_output(cmd)
@@ -221,7 +221,7 @@ class BaseMachine:
         """
         cmd = ["rsync", "-amrh", "-e", "ssh -o StrictHostKeyChecking=no " +
                "-o UserKnownHostsFile=/dev/null -o ControlMaster=auto " +
-               "-o ControlPath='/var/tmp/%%r@%%h-%%p' -o ControlPersist=60" +
+               "-o ControlPath='/var/tmp/%r@%h-%p' -o ControlPersist=60" +
                " -o BatchMode=yes", src, "root@%s:%s" % (self.get_addr(), dst)]
         utils.check_output(cmd)
 


### PR DESCRIPTION
The rsync command is executed without formatting the string, we must not
escape the '%' chars otherwise we escape the ssh command's formatting
and end up with /var/tmp/%r@%h-%p file being used (which hangs on
multiple different sshes).

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>