### PR TITLE
Add "strip-run-perf" script

### DIFF
--- a/docs/source/scripts.rst
+++ b/docs/source/scripts.rst
@@ -537,3 +537,14 @@ a specific example for upstream qemu bisection in
 ``contrib/upstream_qemu_bisect.sh``. You can also check-out
 the :ref:`jenkins` chapter for a jenkins pipeline
 using it.
+
+
+==============
+Strip-run-perf
+==============
+
+This tool can be used to obtain stripped results that only contain the
+bits used by run-perf tools (compare-perf, ...). It can reduce the results
+significantly (MB->KB) but you are going to lose all of the extra
+information essential to debug issues. The primary focus is to keep
+run-perf data while storing the detailed information elsewhere.

--- a/scripts/strip-run-perf
+++ b/scripts/strip-run-perf
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: Red Hat Inc. 2021
+# Author: Lukas Doktor <ldoktor@redhat.com>
+
+import sys
+
+from runperf import StripPerf
+
+
+if __name__ == '__main__':
+    strip = StripPerf()
+    sys.exit(strip())
+

--- a/selftests/core/test_compareperf.py
+++ b/selftests/core/test_compareperf.py
@@ -16,11 +16,13 @@
 Tests for the main runperf app
 """
 
+import glob
 import os
 import re
+import shutil
 from unittest import mock
 
-from runperf import ComparePerf
+from runperf import ComparePerf, StripPerf
 
 from . import Selftest
 
@@ -33,34 +35,35 @@ class RunPerfTest(Selftest):
         self.base_dir = os.path.dirname(os.path.dirname(
             os.path.dirname(__file__)))
 
-    def _run(self, args):
+    def _run(self, args, base_dir):
         old_path = os.getcwd()
         try:
-            os.chdir(self.base_dir)
+            os.chdir(base_dir)
             with mock.patch("sys.argv", args):
                 with mock.patch("logging.getLogger"):
                     return ComparePerf()()
         finally:
             os.chdir(old_path)
 
-    def test_full(self):
+    def test_full_and_stripped(self):
         html_path = os.path.join(self.tmpdir, "result.html")
         xunit_path = os.path.join(self.tmpdir, "result.xunit")
+        model_path = "selftests/.assets/results/1_base/linear_model.json"
+        results = ["selftests/.assets/results/1_base/"
+                   "result_20200726_080654",
+                   "selftests/.assets/results/1_base/result_20200726_112748",
+                   "selftests/.assets/results/2_kernel_update/"
+                   "result_20200726_114437",
+                   "selftests/.assets/results/3_kernel_and_less_cpus/"
+                   "result_20200726_125851", "selftests/.assets/results/"
+                   "4_kernel_and_less_cpus_and_different_duration/"
+                   "result_20200726_130256"]
         args = ["compare-perf", "--html-with-charts",
                 "--tolerance", "5", "--stddev-tolerance", "10",
-                "--model-linear-regression",
-                "selftests/.assets/results/1_base/linear_model.json",
+                "--model-linear-regression", model_path,
                 "--html", html_path, "--xunit", xunit_path,
-                "--", "selftests/.assets/results/1_base/"
-                "result_20200726_080654",
-                "selftests/.assets/results/1_base/result_20200726_112748",
-                "selftests/.assets/results/2_kernel_update/"
-                "result_20200726_114437",
-                "selftests/.assets/results/3_kernel_and_less_cpus/"
-                "result_20200726_125851", "selftests/.assets/results/"
-                "4_kernel_and_less_cpus_and_different_duration/"
-                "result_20200726_130256"]
-        self.assertEqual(self._run(args), 2)
+                "--"]
+        self.assertEqual(self._run(args + results, self.base_dir), 2)
         with open(os.path.join(self.base_dir, "docs", "source", "_static",
                                "html_result.html")) as exp:
             with open(html_path) as act:
@@ -73,13 +76,45 @@ class RunPerfTest(Selftest):
                                   act.read())
                 self.assertEqual(exp.read(), act_filt)
 
+        # Now try it again but using a stripped results
+        old_path = os.getcwd()
+        try:
+            os.chdir(self.base_dir)
+            for result in results:
+                with mock.patch("sys.argv",
+                                ["strip-perf", "-vvv", result,
+                                 os.path.join(self.tmpdir, result)]):
+                    with mock.patch("logging.getLogger"):
+                        StripPerf()()
+                # Make sure the stripped result is smaller than half of the
+                # original file size
+                for path in glob.glob(os.path.join(result, '*', '*', '*',
+                                                   'result.json')):
+                    exp = os.stat(path).st_size / 2
+                    act = os.stat(os.path.join(self.tmpdir, path)).st_size
+                    self.assertLess(act, exp)
+            shutil.copy(model_path, os.path.join(self.tmpdir, model_path))
+        finally:
+            os.chdir(old_path)
+        self.assertEqual(self._run(args + results, self.tmpdir), 2)
+        with open(os.path.join(self.base_dir, "docs", "source", "_static",
+                               "html_result.html")) as exp:
+            with open(html_path) as act:
+                self.assertEqual(exp.read(), act.read())
+        with open(os.path.join(self.base_dir, "selftests", ".assets",
+                               "results", "result.xunit")) as exp:
+            with open(xunit_path) as act:
+                act_filt = re.sub('timestamp="[^"]+"',
+                                  'timestamp="FILTERED"',
+                                  act.read())
+                self.assertEqual(exp.read(), act_filt)
 
     def test(self):
         args = ["compare-perf", "--", "selftests/.assets/results/1_base/"
                 "result_20200726_080654", "selftests/.assets/results/"
                 "4_kernel_and_less_cpus_and_different_duration/"
                 "result_20200726_130256"]
-        self.assertEqual(2, self._run(args))
+        self.assertEqual(2, self._run(args, self.base_dir))
 
     def test_paths(self):
         # with result name
@@ -87,16 +122,16 @@ class RunPerfTest(Selftest):
                 "result_20200726_080654", "selftests/.assets/results/"
                 "4_kernel_and_less_cpus_and_different_duration/"
                 "result_20200726_130256"]
-        self.assertEqual(2, self._run(args))
+        self.assertEqual(2, self._run(args, self.base_dir))
         # with incorrect path
         args = ["compare-perf", "--", "selftests/.assets/results/1_base/"
                 "result_20200726_080654",
                 os.path.join(self.tmpdir, "non", "existing", "location")]
         with mock.patch("sys.stderr"):
-            self.assertRaises(SystemExit, self._run, args)
+            self.assertRaises(SystemExit, self._run, args, self.base_dir)
         # with incorrect named path
         args = ["compare-perf", "--", "selftests/.assets/results/1_base/"
                 "result_20200726_080654", "foo:" +
                 os.path.join(self.tmpdir, "non", "existing", "location")]
         with mock.patch("sys.stderr"):
-            self.assertRaises(SystemExit, self._run, args)
+            self.assertRaises(SystemExit, self._run, args, self.base_dir)

--- a/setup.py
+++ b/setup.py
@@ -81,7 +81,8 @@ if __name__ == '__main__':
           packages=find_packages(exclude=('selftests*',)),
           include_package_data=True,
           scripts=['scripts/run-perf', 'scripts/analyze-perf',
-                   'scripts/compare-perf', 'scripts/diff-perf'],
+                   'scripts/compare-perf', 'scripts/diff-perf',
+                   'scripts/strip-run-perf'],
           entry_points={
               'runperf.profiles': [
                   '50Localhost = runperf.profiles:Localhost',


### PR DESCRIPTION
This script can be used to create a stripped version of the run-perf
results. It removes all the information which is not used by
compare-perf like individual sample values or other assets, but for
compare-perf (and other run-perf related scripts) it should preserve all
of the values. The primary focus is to allow compare-perf/diff-perf/...
execution on a minimal results when the full pbench data are stored
somewhere else.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>