### PR TITLE
Remove extra string from xml results

### DIFF
--- a/runperf/result.py
+++ b/runperf/result.py
@@ -707,8 +707,7 @@ class RelativeResults:
                     errors += 1
                     element_type = 'error'
                 element = document.createElement(element_type)
-                element.setAttribute('type', _str("%s_ELEMENT_TYPE"
-                                                  % element_type))
+                element.setAttribute('type', _str(element_type))
                 element.setAttribute('message', _str(test.details))
                 testcase.appendChild(element)
             testsuite.appendChild(testcase)

--- a/selftests/.assets/results/result.xunit
+++ b/selftests/.assets/results/result.xunit
@@ -1,23 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuite name="runperf" timestamp="FILTERED" tests="32" errors="4" failures="1" skipped="1" time="0.000">
 	<testcase classname="Localhost/fio/0000:./read-4KiB/throughput" name="iops_sec.mean" time="0.000">
-		<failure type="failure_ELEMENT_TYPE" message="SMALL raw -6.83%, avg -16.23% GOOD model0 -4.88%, mraw0 -4.54% (179348.46/183743.17; 171197.389830508) +-5.0% tolerance"/>
+		<failure type="failure" message="SMALL raw -6.83%, avg -16.23% GOOD model0 -4.88%, mraw0 -4.54% (179348.46/183743.17; 171197.389830508) +-5.0% tolerance"/>
 	</testcase>
 	<testcase classname="Localhost/fio/0000:./read-4KiB/throughput" name="iops_sec.stddev" time="0.000"/>
 	<testcase classname="Localhost/fio/0000:./read-64KiB/throughput" name="iops_sec.mean" time="0.000">
-		<skipped type="skipped_ELEMENT_TYPE" message="BIG model0 21.78%, mraw0 19.80%, raw 16.53%, avg 10.94% (100482.88/103308.03; 120381.830508475) +-5.0% tolerance"/>
+		<skipped type="skipped" message="BIG model0 21.78%, mraw0 19.80%, raw 16.53%, avg 10.94% (100482.88/103308.03; 120381.830508475) +-5.0% tolerance"/>
 	</testcase>
 	<testcase classname="Localhost/fio/0000:./read-64KiB/throughput" name="iops_sec.stddev" time="0.000"/>
 	<testcase classname="Localhost2/fio/0000:./read-4KiB/throughput" name="iops_sec.mean" time="0.000">
-		<error type="error_ELEMENT_TYPE" message="Not present in target results (-100)"/>
+		<error type="error" message="Not present in target results (-100)"/>
 	</testcase>
 	<testcase classname="Localhost2/fio/0000:./read-4KiB/throughput" name="iops_sec.stddev" time="0.000">
-		<error type="error_ELEMENT_TYPE" message="Not present in target results (-100)"/>
+		<error type="error" message="Not present in target results (-100)"/>
 	</testcase>
 	<testcase classname="Localhost2/fio/0000:./read-64KiB/throughput" name="iops_sec.mean" time="0.000">
-		<error type="error_ELEMENT_TYPE" message="Not present in target results (-100)"/>
+		<error type="error" message="Not present in target results (-100)"/>
 	</testcase>
 	<testcase classname="Localhost2/fio/0000:./read-64KiB/throughput" name="iops_sec.stddev" time="0.000">
-		<error type="error_ELEMENT_TYPE" message="Not present in target results (-100)"/>
+		<error type="error" message="Not present in target results (-100)"/>
 	</testcase>
 </testsuite>


### PR DESCRIPTION
there was an extra "_ELEMENT_TYPE" suffix to the result type, remove it.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>