### PR TITLE
Analyze-perf little fixes

### DIFF
--- a/runperf/result.py
+++ b/runperf/result.py
@@ -234,8 +234,8 @@ class ModelStdev(ModelLinearRegression):
             uncertainty = get_uncertainty(len(values))
             average = numpy.average(values)
             max_stddev = self.ERROR_COEFICIENT * numpy.std(values)
-            max_value = (average + max_stddev) * uncertainty
-            min_value = (average - max_stddev) * uncertainty
+            max_value = average + (max_stddev * uncertainty)
+            min_value = average - (max_stddev * uncertainty)
             model = self._identify(min_value, max_value)
             if not model:
                 # Singular matrix, not possible to map

--- a/runperf/result.py
+++ b/runperf/result.py
@@ -172,7 +172,11 @@ class ModelLinearRegression(Model):
         too_strict_coefficient = (self.mean_tolerance / 100 /
                                   self.TOO_STRICT_COEFFICIENT)
         for test in sorted(data.keys()):
-            values = [float(_) for _ in data.get(test, {}).values()]
+            try:
+                values = [float(_) for _ in data.get(test, {}).values()]
+            except ValueError:
+                # Probably string (error, other kind of result)
+                continue
             average = numpy.average(values)
             max_value = max(values)
             highest = average * (1 + too_strict_coefficient)
@@ -222,7 +226,11 @@ class ModelStdev(ModelLinearRegression):
             self.model["__metadata__"] = {"version": 1}
         self.model["__metadata__"]["tolerance"] = self.mean_tolerance
         for test in sorted(data.keys()):
-            values = [float(_) for _ in data.get(test, {}).values()]
+            try:
+                values = [float(_) for _ in data.get(test, {}).values()]
+            except ValueError:
+                # Probably string (error, other kind of result)
+                continue
             uncertainty = get_uncertainty(len(values))
             average = numpy.average(values)
             max_stddev = self.ERROR_COEFICIENT * numpy.std(values)

--- a/selftests/core/test_analyzeperf.py
+++ b/selftests/core/test_analyzeperf.py
@@ -67,3 +67,16 @@ class RunPerfTest(Selftest):
                                "results", "data.csv")) as exp:
             with open(path_csv) as act:
                 self.assertEqual(exp.read(), act.read())
+
+    def test_bad(self):
+        """Make sure we are not crashing on 'bad' results"""
+        path_model = os.path.join(self.tmpdir, "model.json")
+        path_model_stddev = os.path.join(self.tmpdir, "model_stddev.json")
+        path_csv = os.path.join(self.tmpdir, "data.csv")
+        args = ["analyze-perf", "-l", path_model, "-s", path_model_stddev,
+                "-c", path_csv, "--"]
+        res = [os.path.join("selftests/.assets/results/9_bad/", _)
+               for _ in ("result_20200726_091827", "result_20200726_114437",
+                         "result_three_bad", "result_two_bad")]
+        args.extend(res)
+        self.assertEqual(self._run(args), None)


### PR DESCRIPTION
We forgot about analyze-perf when introducing the error (string) results and there is a min/max value evaluation issue in the stddev model.