### PR TITLE
Use uncertainty for group results tolerances

### DIFF
--- a/docs/source/_static/html_result.html
+++ b/docs/source/_static/html_result.html
@@ -11965,24 +11965,24 @@ Localhost2/fio/0000:./read-64KiB/throughput/iops_sec.stddev</pre></span></div></
     </tr>
     <tr class=" status_2 any_status_2 any_status_-1 any_status_2 ">
         <td class="status_*/fio/0000:./read-*/throughput/iops_sec.mean"><div class="tooltip">*/fio/0000:./read-*/throughput/iops_sec.mean<span class="tooltiptext">*/fio/0000:./read-*/throughput/iops_sec.mean</span></div></td>
-        <td class="status_2"><div class="tooltip">-4.0<span class="tooltiptext">GOOD raw -4.01% (-4.01; -4.005453993002888) +-5.0% tolerance</span></div></td>
-        <td class="status_2"><div class="tooltip">-1.1<span class="tooltiptext">GOOD raw -1.07% (-1.07; -1.0650041317484664) +-5.0% tolerance</span></div></td>
-        <td class="status_-1"><div class="tooltip">-8.7<span class="tooltiptext">SMALL raw -8.67% (-8.67; -8.667814451256838) +-5.0% tolerance</span></div></td>
-        <td class="status_2"><div class="tooltip">0.2<span class="tooltiptext">GOOD raw 3.83%, avg -4.96% (3.83; 3.827455277150146) +-5.0% tolerance</span></div></td>
+        <td class="status_2"><div class="tooltip">-4.0<span class="tooltiptext">GOOD raw -4.01% (-4.01; -4.005453993002888) +-5.75% tolerance</span></div></td>
+        <td class="status_2"><div class="tooltip">-1.1<span class="tooltiptext">GOOD raw -1.07% (-1.07; -1.0650041317484664) +-5.75% tolerance</span></div></td>
+        <td class="status_-1"><div class="tooltip">-8.7<span class="tooltiptext">SMALL raw -8.67% (-8.67; -8.667814451256838) +-5.75% tolerance</span></div></td>
+        <td class="status_2"><div class="tooltip">0.2<span class="tooltiptext">GOOD raw 3.83%, avg -4.96% (3.83; 3.827455277150146) +-5.75% tolerance</span></div></td>
     </tr>
     <tr class=" status_2 any_status_2 any_status_-1 any_status_2 ">
         <td class="status_Localhost/*/*:./*-*/*/*.mean"><div class="tooltip">Localhost/*/*:./*-*/*/*.mean<span class="tooltiptext">Localhost/*/*:./*-*/*/*.mean</span></div></td>
-        <td class="status_2"><div class="tooltip">-4.0<span class="tooltiptext">GOOD raw -4.01% (-4.01; -4.005453993002888) +-5.0% tolerance</span></div></td>
-        <td class="status_2"><div class="tooltip">-1.1<span class="tooltiptext">GOOD raw -1.07% (-1.07; -1.0650041317484664) +-5.0% tolerance</span></div></td>
-        <td class="status_-1"><div class="tooltip">-8.7<span class="tooltiptext">SMALL raw -8.67% (-8.67; -8.667814451256838) +-5.0% tolerance</span></div></td>
-        <td class="status_2"><div class="tooltip">0.2<span class="tooltiptext">GOOD raw 3.83%, avg -4.96% (3.83; 3.827455277150146) +-5.0% tolerance</span></div></td>
+        <td class="status_2"><div class="tooltip">-4.0<span class="tooltiptext">GOOD raw -4.01% (-4.01; -4.005453993002888) +-5.75% tolerance</span></div></td>
+        <td class="status_2"><div class="tooltip">-1.1<span class="tooltiptext">GOOD raw -1.07% (-1.07; -1.0650041317484664) +-5.75% tolerance</span></div></td>
+        <td class="status_-1"><div class="tooltip">-8.7<span class="tooltiptext">SMALL raw -8.67% (-8.67; -8.667814451256838) +-5.75% tolerance</span></div></td>
+        <td class="status_2"><div class="tooltip">0.2<span class="tooltiptext">GOOD raw 3.83%, avg -4.96% (3.83; 3.827455277150146) +-5.75% tolerance</span></div></td>
     </tr>
     <tr class=" status_2 any_status_2 any_status_-1 any_status_2 ">
         <td class="status_Localhost/fio/0000:./read-*/throughput/iops_sec.mean"><div class="tooltip">Localhost/fio/0000:./read-*/throughput/iops_sec.mean<span class="tooltiptext">Localhost/fio/0000:./read-*/throughput/iops_sec.mean</span></div></td>
-        <td class="status_2"><div class="tooltip">-4.0<span class="tooltiptext">GOOD raw -4.01% (-4.01; -4.005453993002888) +-5.0% tolerance</span></div></td>
-        <td class="status_2"><div class="tooltip">-1.1<span class="tooltiptext">GOOD raw -1.07% (-1.07; -1.0650041317484664) +-5.0% tolerance</span></div></td>
-        <td class="status_-1"><div class="tooltip">-8.7<span class="tooltiptext">SMALL raw -8.67% (-8.67; -8.667814451256838) +-5.0% tolerance</span></div></td>
-        <td class="status_2"><div class="tooltip">0.2<span class="tooltiptext">GOOD raw 3.83%, avg -4.96% (3.83; 3.827455277150146) +-5.0% tolerance</span></div></td>
+        <td class="status_2"><div class="tooltip">-4.0<span class="tooltiptext">GOOD raw -4.01% (-4.01; -4.005453993002888) +-5.75% tolerance</span></div></td>
+        <td class="status_2"><div class="tooltip">-1.1<span class="tooltiptext">GOOD raw -1.07% (-1.07; -1.0650041317484664) +-5.75% tolerance</span></div></td>
+        <td class="status_-1"><div class="tooltip">-8.7<span class="tooltiptext">SMALL raw -8.67% (-8.67; -8.667814451256838) +-5.75% tolerance</span></div></td>
+        <td class="status_2"><div class="tooltip">0.2<span class="tooltiptext">GOOD raw 3.83%, avg -4.96% (3.83; 3.827455277150146) +-5.75% tolerance</span></div></td>
     </tr>
     </table>
 </div>

--- a/runperf/result.py
+++ b/runperf/result.py
@@ -847,8 +847,10 @@ class RelativeResults:
             values[record_id].append(record.score)
         for test_name, values in values.items():
             value = numpy.average(values)
+            # Use half of mean_tolerance * uncertainty
+            tolerance = self.mean_tolerance * get_uncertainty(len(values)) / 2
             self.record_result(test_name, value, value, True, True,
-                               value, self.mean_tolerance)
+                               value, tolerance)
 
     def expand_grouped_results(self):
         """


### PR DESCRIPTION
The group results combine multiple results to represent certain group.
The more results in the same group there are the greater probability of
the spread to be closer to 0. Let's use the uncertainty we use elsewhere
to decrease the tolerance.

As we want to be stricter than with normal results divide the resulting
tolerance by 2 (for now, maybe consider customization if needed).

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>