### PR TITLE
Try to re-apply profile on failure

### DIFF
--- a/runperf/machine.py
+++ b/runperf/machine.py
@@ -297,6 +297,9 @@ class Controller:
             thread.join()
         for thread in threads:
             if thread.completed is not True:
+                if thread.exc:
+                    raise RuntimeError("Thread %s failed"
+                                       % thread) from thread.exc
                 raise RuntimeError("Thread %s failed" % thread)
         reboot_request = [host for host in hosts if host.reboot_request]
         if reboot_request:

--- a/runperf/tests.py
+++ b/runperf/tests.py
@@ -164,7 +164,11 @@ class PBenchTest(BaseTest):
             thread.join()
         failed = [thread for thread in threads if thread.completed is not True]
         if failed:
-            raise RuntimeError("Failed to install pbench on %s" % failed)
+            for thread in threads:
+                if thread.exc:
+                    raise RuntimeError("Failed to install pbench on %s"
+                                       % failed) from thread.exc
+                raise RuntimeError("Failed to install pbench on %s" % failed)
         # Wait for the machines to calm down before the testing and use
         # hop=self.host as the host will be executing the ssh commands.
         for workers in self.workers:

--- a/runperf/tests.py
+++ b/runperf/tests.py
@@ -179,8 +179,8 @@ class PBenchTest(BaseTest):
                                            " proceeding on a loaded machine!")
         with self.host.get_session_cont(hop=self.host) as session:
             if not utils.wait_for_machine_calms_down(session, timeout=1800):
-                worker.log.warning("Host did not stabilize in 1800s,"
-                                   " proceeding on a loaded machine!")
+                self.host.log.warning("Host did not stabilize in 1800s,"
+                                      " proceeding on a loaded machine!")
 
     def _run(self):
         # We only need one group of workers

--- a/runperf/tests.py
+++ b/runperf/tests.py
@@ -168,8 +168,13 @@ class PBenchTest(BaseTest):
                     raise RuntimeError("Failed to install pbench on %s"
                                        % failed) from thread.exc
                 raise RuntimeError("Failed to install pbench on %s" % failed)
-        # Wait for the machines to calm down before the testing and use
-        # hop=self.host as the host will be executing the ssh commands.
+        self._wait_for_workers_calm_down()
+
+    def _wait_for_workers_calm_down(self):
+        """
+        Wait for the machines to calm down before the testing and use
+        hop=self.host as the host will be executing the ssh commands.
+        """
         for workers in self.workers:
             for worker in workers:
                 with worker.get_session_cont(hop=self.host) as session:

--- a/runperf/tests.py
+++ b/runperf/tests.py
@@ -138,7 +138,6 @@ class PBenchTest(BaseTest):
         def install_pbench(host, metadata, test):
             with host.get_session_cont() as session:
                 pbench.install_on(session, metadata, test=test)
-        install_pbench(self.host, self.metadata, self.test)
         threads = []
         if self.host in self.workers:
             # When host is also in workers, perform install first on host

--- a/runperf/utils/__init__.py
+++ b/runperf/utils/__init__.py
@@ -48,10 +48,14 @@ class ThreadWithStatus(threading.Thread):
     Thread class that sets "self.completed" to True after execution
     """
     completed = False
+    exc = None
 
     def run(self):
-        super().run()
-        self.completed = True
+        try:
+            super().run()
+            self.completed = True
+        except BaseException as exc:
+            self.exc = exc
 
 
 class MutableShellSession(aexpect.ShellSession):

--- a/runperf/utils/__init__.py
+++ b/runperf/utils/__init__.py
@@ -54,11 +54,11 @@ class ThreadWithStatus(threading.Thread):
         try:
             super().run()
             self.completed = True
-        except BaseException as exc:
+        except BaseException as exc:  # lgtm [py/catch-base-exception]
             self.exc = exc
 
 
-class MutableShellSession(aexpect.ShellSession):
+class MutableShellSession(aexpect.ShellSession):  # lgtm [py/missing-call-to-init]
     """
     Mute-able aexpect.ShellSession
     """

--- a/selftests/utils/test_utils.py
+++ b/selftests/utils/test_utils.py
@@ -26,6 +26,23 @@ import contextlib
 
 class BasicUtils(unittest.TestCase):
 
+    def test_thread_with_status(self):
+        def no_exc():
+            pass
+
+        def exc():
+            raise Exception("Testing exception")
+
+        good = utils.ThreadWithStatus(target=no_exc)
+        good.start()
+        good.join()
+        self.assertTrue(good.completed)
+        bad = utils.ThreadWithStatus(target=exc)
+        bad.start()
+        bad.join()
+        self.assertFalse(bad.completed)
+        self.assertIn(str(bad.exc), "Testing exception")
+
     def test_list_of_threads(self):
         self.assertRaises(ValueError, utils.list_of_threads, -5)
         self.assertRaises(ValueError, utils.list_of_threads, 0)


### PR DESCRIPTION
Currently we skip the profile and proceed with the next one. Let's allow to re-apply the profile multiple times. It should not interfere with the results as no tests were executed and we attempt to revert the profile.