### PR TITLE
Fix host detection in list of workers

### DIFF
--- a/runperf/tests.py
+++ b/runperf/tests.py
@@ -139,9 +139,11 @@ class PBenchTest(BaseTest):
             with host.get_session_cont() as session:
                 pbench.install_on(session, metadata, test=test)
         threads = []
-        if self.host in self.workers:
-            # When host is also in workers, perform install first on host
-            install_pbench(self.host, self.metadata, self.test)
+        for host_workers in self.workers:
+            if self.host in host_workers:
+                # When host is also in workers, perform install first on host
+                install_pbench(self.host, self.metadata, self.test)
+                break
         else:
             name = "host %s" % self.host.name
             threads.append(utils.ThreadWithStatus(target=install_pbench,


### PR DESCRIPTION
The list of workers is actually a list of lists of per-host workers. In
order to detect the host properly we have to iterate throught them.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>