### PR TITLE
Avoid false shell_find_command results

### DIFF
--- a/runperf/utils/__init__.py
+++ b/runperf/utils/__init__.py
@@ -368,8 +368,11 @@ def shell_find_command(session, command):
     :param command: command we are looking for
     :return: path or empty string when not found
     """
-    return session.cmd_output("which --skip-alias --skip-functions %s "
-                              "2>/dev/null" % command).strip()
+    stat, out = session.cmd_status_output("which --skip-alias --skip-functions"
+                                          " %s 2>/dev/null" % command)
+    if stat == 0:
+        return out.strip()
+    return ''
 
 
 def wait_for_machine_calms_down(session, timeout=600):

--- a/selftests/core/test_tests.py
+++ b/selftests/core/test_tests.py
@@ -53,7 +53,8 @@ class PBenchTest(Selftest):
         mock_args = {'cmd_status.return_value': 0,
                      'cmd_output.side_effect': (
                          prepend_host_cmd_output_side_effect +
-                         ["", "prefix+self._cmd", "0", result_path])}
+                         ["prefix+self._cmd", "0", result_path]),
+                     'cmd_status_output.return_value': [1, ""]}
         host.mock_session = mock.Mock(**mock_args)
         host.profile = mock.Mock()
         host.profile.name = profile

--- a/selftests/utils/test_utils.py
+++ b/selftests/utils/test_utils.py
@@ -77,6 +77,15 @@ class BasicUtils(unittest.TestCase):
         # read on closed stdin should return immediately (otherwise it hangs)
         self.assertEqual("", utils.check_output(["cat", "/dev/stdin"]))
 
+    def test_shell_find_command(self):
+        session = mock.Mock()
+        session.cmd_status_output.return_value = (0, "  \n /bin/foo\n\n  ")
+        self.assertEqual(utils.shell_find_command(session, "bar"), "/bin/foo")
+        session.cmd_status_output.return_value = (1, "/bin/foo")
+        self.assertEqual(utils.shell_find_command(session, "bar"), "")
+        session.cmd_status_output.return_value = (0, "")
+        self.assertEqual(utils.shell_find_command(session, ""), "")
+
     def test_wait_for(self):
         with mock.patch("time.time", mock.Mock(side_effect=[0, 0, 0])):
             func = mock.Mock(side_effect=[0, 1])


### PR DESCRIPTION
On overloaded systems the utils.shell_find_command() might return the
echoed command. Let's additionally check for the status to at least
minimize the probability of returning false-positive.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>