### PR TITLE
Report the number of runtime errors in html report

### DIFF
--- a/docs/source/_static/html_result.html
+++ b/docs/source/_static/html_result.html
@@ -11901,6 +11901,14 @@ Localhost2/fio/0000:./read-64KiB/throughput/iops_sec.stddev</pre></span></div></
         <td style='background-color: rgba(255, 102.0, 102.0)'>28</td>
         <td style='background-color: rgba(255, 153.0, 153.0)'>16</td>
     <tr>
+        <td>Runtime errors</td>
+        <td style='background-color: rgba(255, 255.0, 255.0)'></td>
+        <td style='background-color: rgba(255, 204.0, 204.0)'>0</td>
+        <td style='background-color: rgba(255, 204.0, 204.0)'>0</td>
+        <td style='background-color: rgba(255, 102.0, 102.0)'>0</td>
+        <td style='background-color: rgba(255, 153.0, 153.0)'>0</td>
+    </tr>
+    <tr>
         <td>Total checks</td>
         <td style='background-color: rgba(255, 255.0, 255.0)'></td>
         <td style='background-color: rgba(255, 204.0, 204.0)'>35</td>

--- a/runperf/assets/html_report/report_template.html
+++ b/runperf/assets/html_report/report_template.html
@@ -10558,6 +10558,10 @@ a {font-family: monospace;}
         <td>Non-primary failures</td>{% for build in builds %}
         <td style='{{ relative_score_color(build) }}'>{{build.non_primary_failures}}</td>{% endfor %}
     <tr>
+        <td>Runtime errors</td>{% for build in builds %}
+        <td style='{{ relative_score_color(build) }}'>{{build.errors}}</td>{% endfor %}
+    </tr>
+    <tr>
         <td>Total checks</td>{% for build in builds %}
         <td style='{{ relative_score_color(build) }}'>{{build.total}}</td>{% endfor %}
     </tr>

--- a/runperf/assets/html_report/report_template.html.variables
+++ b/runperf/assets/html_report/report_template.html.variables
@@ -18,6 +18,7 @@ builds: [src, reference1, reference2, ..., dst]     # List of all involved build
         environment_diff_sections: {'world': [1], 'profile': [5], ...}  # How many sections contain non-empty diff (per machine)
         failures: 3     # Number of failures in this build
         group_failures: 0   # Number of group failures in this build
+        errors: 3	# Number of errors (provisioning/runtime/... issues)
         total: 357      # Overall number of checks
         score: 31       # Overall build score (calculated from failures, group_failures, ...
         relative_score: 2   # Relative score to other builds (sorted list 0-n), multiple same entries possible

--- a/runperf/html_report.py
+++ b/runperf/html_report.py
@@ -276,19 +276,25 @@ def generate_report(path, results, with_charts=False, small_file=False):
         for res in reversed(results):
             build = process_metadata(res.metadata, known_items, dst_env,
                                      small_file)
-            failures = grouped_failures = non_primary_failures = 0
+            failures = grouped_failures = non_primary_failures = errors = 0
             for record in res.records:
                 if record.status < 0:
-                    if record.primary:
+                    if record.is_error():
+                        errors += 1
+                    elif record.primary:
                         failures += 1
                     else:
                         non_primary_failures += 1
             for record in res.grouped_records:
                 if record.status < 0:
-                    grouped_failures += 1
+                    if record.status == result.ERROR:
+                        errors += 1
+                    else:
+                        grouped_failures += 1
             build["failures"] = failures
             build["group_failures"] = grouped_failures
             build["non_primary_failures"] = non_primary_failures
+            build["errors"] = errors
             build["total"] = len(res.records) + len(res.grouped_records)
             build["score"] = int(build["failures"] +
                                  5 * build["group_failures"] +

--- a/runperf/result.py
+++ b/runperf/result.py
@@ -301,6 +301,10 @@ class Result:
         """Whether this result is "stddev" result (or mean)"""
         return self.testname.endswith("stddev")
 
+    def is_error(self):
+        """Whether this result is a runtime error"""
+        return self.testname.endswith("error")
+
     @property
     def name(self):
         """Full test name"""

--- a/selftests/core/test_runperf.py
+++ b/selftests/core/test_runperf.py
@@ -105,8 +105,11 @@ class RunPerfTest(Selftest):
                     with mock.patch("runperf.machine.BaseMachine.copy_from",
                                     lambda _, src, dst: shutil.copy(src, dst)):
                         with mock.patch("runperf.machine.BaseMachine.copy_to",
-                                        lambda _, src, dst: shutil.copy(src, dst)):
-                            main()
+                                        lambda _, src, dst: shutil.copy(src,
+                                                                        dst)):
+                            with mock.patch("runperf.machine.Controller."
+                                            "fetch_logs"):
+                                main()
         # Check only for test dirs, metadata are checked in other tests
         self.assertTrue(os.path.exists(os.path.join(self.tmpdir, "result")))
         for serial in ["0000", "0001"]:


### PR DESCRIPTION
the number of generic/runtime errors is currently part of the failures,
but it doesn't really fit there and should be reported separately
(especially because on generic/runtime error we usually recover and
repeat the step). Let's report them individually as Runtime errors in
the html report.