### PR TITLE
contrib: Update the default qemu ./configure

### DIFF
--- a/contrib/upstream_qemu_bisect.sh
+++ b/contrib/upstream_qemu_bisect.sh
@@ -99,7 +99,7 @@ for AAA in $(seq 1 3); do
 done
 VERSION=$(git rev-parse HEAD)
 #./configure --target-list="$(uname -m)"-softmmu
-./configure --target-list="$(uname -m)"-softmmu --disable-werror --enable-kvm --enable-vhost-net --enable-attr --enable-fdt --enable-vnc --enable-seccomp --enable-spice --enable-usb-redir --with-pkgversion="$VERSION" || { echo "Qemu ./confiugre FAILed"; exit -1; }
+./configure --target-list="$(uname -m)"-softmmu --disable-werror --enable-kvm --enable-vhost-net --enable-attr --enable-fdt --enable-vnc --enable-seccomp --enable-usb-redir --disable-opengl --disable-virglrenderer --with-pkgversion="$VERSION" || { echo "Qemu ./confiugre FAILed"; exit -1; }
 make -j $(getconf _NPROCESSORS_ONLN) || { echo "Qemu make FAILed"; exit -1; }
 make install || { echo "Qemu make install FAILed"; exit -1; }
 chcon -Rt qemu_exec_t /usr/local/bin/qemu-system-"$(uname -m)"


### PR DESCRIPTION
certain libs are not available on RHEL, let's change the default in
upstream for now before we add a support to set it as a parameter.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>