### PR TITLE
Add n-out-of-results modifier

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ pypi: clean develop
 	@echo "to upload this release"
 
 html_result: develop
-	python3 scripts/compare-perf --html-with-charts -vvv --tolerance 5 --stddev-tolerance 10 --model-linear-regression selftests/.assets/results/1_base/linear_model.json --html docs/source/_static/html_result.html --xunit selftests/.assets/results/result.xunit -- selftests/.assets/results/1_base/result_20200726_080654 selftests/.assets/results/1_base/result_20200726_112748 selftests/.assets/results/2_kernel_update/result_20200726_114437 selftests/.assets/results/3_kernel_and_less_cpus/result_20200726_125851 selftests/.assets/results/4_kernel_and_less_cpus_and_different_duration/result_20200726_130256 || true
+	python3 scripts/compare-perf --html-with-charts -vvv --tolerance 5 --stddev-tolerance 10 --model-linear-regression selftests/.assets/results/1_base/linear_model.json --model-builds-average 1 --html docs/source/_static/html_result.html --xunit selftests/.assets/results/result.xunit -- selftests/.assets/results/1_base/result_20200726_080654 selftests/.assets/results/1_base/result_20200726_112748 selftests/.assets/results/2_kernel_update/result_20200726_114437 selftests/.assets/results/3_kernel_and_less_cpus/result_20200726_125851 selftests/.assets/results/4_kernel_and_less_cpus_and_different_duration/result_20200726_130256 || true
 	sed -i -E 's/timestamp="[^"]+"/timestamp="FILTERED"/' selftests/.assets/results/result.xunit
 
 json_model: develop

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ pypi: clean develop
 	@echo "to upload this release"
 
 html_result: develop
-	python3 scripts/compare-perf --html-with-charts -vvv --tolerance 5 --stddev-tolerance 10 --model-linear-regression selftests/.assets/results/1_base/linear_model.json --model-builds-average 1 --html docs/source/_static/html_result.html --xunit selftests/.assets/results/result.xunit -- selftests/.assets/results/1_base/result_20200726_080654 selftests/.assets/results/1_base/result_20200726_112748 selftests/.assets/results/2_kernel_update/result_20200726_114437 selftests/.assets/results/3_kernel_and_less_cpus/result_20200726_125851 selftests/.assets/results/4_kernel_and_less_cpus_and_different_duration/result_20200726_130256 || true
+	python3 scripts/compare-perf --html-with-charts -vvv --tolerance 5 --stddev-tolerance 10 --model-linear-regression selftests/.assets/results/1_base/linear_model.json --model-builds-average 1 --n-out-of-results 1 --html docs/source/_static/html_result.html --xunit selftests/.assets/results/result.xunit -- selftests/.assets/results/1_base/result_20200726_080654 selftests/.assets/results/1_base/result_20200726_112748 selftests/.assets/results/2_kernel_update/result_20200726_114437 selftests/.assets/results/3_kernel_and_less_cpus/result_20200726_125851 selftests/.assets/results/4_kernel_and_less_cpus_and_different_duration/result_20200726_130256 || true
 	sed -i -E 's/timestamp="[^"]+"/timestamp="FILTERED"/' selftests/.assets/results/result.xunit
 
 json_model: develop

--- a/docs/source/_static/html_result.html
+++ b/docs/source/_static/html_result.html
@@ -12093,28 +12093,28 @@ Localhost2/fio/0000:./read-64KiB/throughput/iops_sec.stddev</pre></span></div></
     </tr>
     <tr class=" status_-2 any_status_-2 any_status_-2 any_status_-2 ">
         <td class="status_Localhost2/fio/0000:./read-4KiB/throughput/iops_sec.mean"><div class="tooltip" onclick="elementValueToClipboard('env-test-5-1-raw')">Localhost2/fio/0000:./read-4KiB/throughput/iops_sec.mean<textarea style="position: absolute; left: -9999px;"  id="env-test-5-1-raw">{0: &#39;benchmark_name:fio\nbs:4k\nclocksource:gettimeofday\ndirect:1\nfilename:/fio\niodepth:32\nioengine:libaio\nlog_avg_msec:1000\nlog_hist_msec:10000\nmax_stddevpct:5\nnumjobs:1\nprimary_metric:iops_sec\nramp_time:5\nruntime:60\nrw:read\nsize:1300000\nsync:0\ntime_based:1\nuid:benchmark_name:%benchmark_name%-controller_host:%controller_host%&#39;, &#39;user0&#39;: &#39;profile: Localhost&#39;}</textarea>&#x1f527;<span class="tooltiptext">Localhost2/fio/0000:./read-4KiB/throughput/iops_sec.mean<br><a href='#'>Click to copy raw src test params</a></span></div></td>
-        <td class="status_-2"><div class="tooltip" onclick="elementValueToClipboard('env-test-5-2-raw')">-100.0<textarea style="position: absolute; left: -9999px;"  id="env-test-5-2-raw">{0: &#39;&#39;, &#39;user0&#39;: &#39;&#39;}</textarea>&#x1f527;<span class="tooltiptext">Not present in target results (-100)<br><a href='#'>Test params differ (click to copy raw value):</a><pre>
+        <td class="status_-2"><div class="tooltip" onclick="elementValueToClipboard('env-test-5-2-raw')">-100.0<textarea style="position: absolute; left: -9999px;"  id="env-test-5-2-raw">{0: &#39;&#39;, &#39;user0&#39;: &#39;&#39;}</textarea>&#x1f527;<span class="tooltiptext">ERROR  Not present in target results (-100) (0; -100) +-1% tolerance<br><a href='#'>Test params differ (click to copy raw value):</a><pre>
 0
 =
 -MISSING IN THIS PARAMS
 user0
 =====
 -MISSING IN THIS PARAMS</pre></span></div></td>
-        <td class="status_-2"><div class="tooltip" onclick="elementValueToClipboard('env-test-5-3-raw')">-100.0<textarea style="position: absolute; left: -9999px;"  id="env-test-5-3-raw">{0: &#39;&#39;, &#39;user0&#39;: &#39;&#39;}</textarea>&#x1f527;<span class="tooltiptext">Not present in target results (-100)<br><a href='#'>Test params differ (click to copy raw value):</a><pre>
+        <td class="status_-2"><div class="tooltip" onclick="elementValueToClipboard('env-test-5-3-raw')">-100.0<textarea style="position: absolute; left: -9999px;"  id="env-test-5-3-raw">{0: &#39;&#39;, &#39;user0&#39;: &#39;&#39;}</textarea>&#x1f527;<span class="tooltiptext">ERROR  Not present in target results (-100) (0; -100) +-1% tolerance<br><a href='#'>Test params differ (click to copy raw value):</a><pre>
 0
 =
 -MISSING IN THIS PARAMS
 user0
 =====
 -MISSING IN THIS PARAMS</pre></span></div></td>
-        <td class="status_-2"><div class="tooltip" onclick="elementValueToClipboard('env-test-5-4-raw')">-100.0<textarea style="position: absolute; left: -9999px;"  id="env-test-5-4-raw">{0: &#39;&#39;, &#39;user0&#39;: &#39;&#39;}</textarea>&#x1f527;<span class="tooltiptext">Not present in target results (-100)<br><a href='#'>Test params differ (click to copy raw value):</a><pre>
+        <td class="status_-2"><div class="tooltip" onclick="elementValueToClipboard('env-test-5-4-raw')">-100.0<textarea style="position: absolute; left: -9999px;"  id="env-test-5-4-raw">{0: &#39;&#39;, &#39;user0&#39;: &#39;&#39;}</textarea>&#x1f527;<span class="tooltiptext">ERROR  Not present in target results (-100) (0; -100) +-1% tolerance<br><a href='#'>Test params differ (click to copy raw value):</a><pre>
 0
 =
 -MISSING IN THIS PARAMS
 user0
 =====
 -MISSING IN THIS PARAMS</pre></span></div></td>
-        <td class="status_-2"><div class="tooltip" onclick="elementValueToClipboard('env-test-5-5-raw')">-100.0<textarea style="position: absolute; left: -9999px;"  id="env-test-5-5-raw">{0: &#39;&#39;, &#39;user0&#39;: &#39;&#39;}</textarea>&#x1f527;<span class="tooltiptext">Not present in target results (-100)<br><a href='#'>Test params differ (click to copy raw value):</a><pre>
+        <td class="status_-2"><div class="tooltip" onclick="elementValueToClipboard('env-test-5-5-raw')">-100.0<textarea style="position: absolute; left: -9999px;"  id="env-test-5-5-raw">{0: &#39;&#39;, &#39;user0&#39;: &#39;&#39;}</textarea>&#x1f527;<span class="tooltiptext">ERROR  Not present in target results (-100) (0; -100) +-1% tolerance<br><a href='#'>Test params differ (click to copy raw value):</a><pre>
 0
 =
 -MISSING IN THIS PARAMS
@@ -12124,28 +12124,28 @@ user0
     </tr>
     <tr class=" status_-2 any_status_-2 any_status_-2 any_status_-2 ">
         <td class="status_Localhost2/fio/0000:./read-4KiB/throughput/iops_sec.stddev"><div class="tooltip" onclick="elementValueToClipboard('env-test-6-1-raw')">Localhost2/fio/0000:./read-4KiB/throughput/iops_sec.stddev<textarea style="position: absolute; left: -9999px;"  id="env-test-6-1-raw">{0: &#39;benchmark_name:fio\nbs:4k\nclocksource:gettimeofday\ndirect:1\nfilename:/fio\niodepth:32\nioengine:libaio\nlog_avg_msec:1000\nlog_hist_msec:10000\nmax_stddevpct:5\nnumjobs:1\nprimary_metric:iops_sec\nramp_time:5\nruntime:60\nrw:read\nsize:1300000\nsync:0\ntime_based:1\nuid:benchmark_name:%benchmark_name%-controller_host:%controller_host%&#39;, &#39;user0&#39;: &#39;profile: Localhost&#39;}</textarea>&#x1f527;<span class="tooltiptext">Localhost2/fio/0000:./read-4KiB/throughput/iops_sec.stddev<br><a href='#'>Click to copy raw src test params</a></span></div></td>
-        <td class="status_-2"><div class="tooltip" onclick="elementValueToClipboard('env-test-6-2-raw')">-100.0<textarea style="position: absolute; left: -9999px;"  id="env-test-6-2-raw">{0: &#39;&#39;, &#39;user0&#39;: &#39;&#39;}</textarea>&#x1f527;<span class="tooltiptext">Not present in target results (-100)<br><a href='#'>Test params differ (click to copy raw value):</a><pre>
+        <td class="status_-2"><div class="tooltip" onclick="elementValueToClipboard('env-test-6-2-raw')">-100.0<textarea style="position: absolute; left: -9999px;"  id="env-test-6-2-raw">{0: &#39;&#39;, &#39;user0&#39;: &#39;&#39;}</textarea>&#x1f527;<span class="tooltiptext">ERROR  Not present in target results (-100) (0; -100) +-1% tolerance<br><a href='#'>Test params differ (click to copy raw value):</a><pre>
 0
 =
 -MISSING IN THIS PARAMS
 user0
 =====
 -MISSING IN THIS PARAMS</pre></span></div></td>
-        <td class="status_-2"><div class="tooltip" onclick="elementValueToClipboard('env-test-6-3-raw')">-100.0<textarea style="position: absolute; left: -9999px;"  id="env-test-6-3-raw">{0: &#39;&#39;, &#39;user0&#39;: &#39;&#39;}</textarea>&#x1f527;<span class="tooltiptext">Not present in target results (-100)<br><a href='#'>Test params differ (click to copy raw value):</a><pre>
+        <td class="status_-2"><div class="tooltip" onclick="elementValueToClipboard('env-test-6-3-raw')">-100.0<textarea style="position: absolute; left: -9999px;"  id="env-test-6-3-raw">{0: &#39;&#39;, &#39;user0&#39;: &#39;&#39;}</textarea>&#x1f527;<span class="tooltiptext">ERROR  Not present in target results (-100) (0; -100) +-1% tolerance<br><a href='#'>Test params differ (click to copy raw value):</a><pre>
 0
 =
 -MISSING IN THIS PARAMS
 user0
 =====
 -MISSING IN THIS PARAMS</pre></span></div></td>
-        <td class="status_-2"><div class="tooltip" onclick="elementValueToClipboard('env-test-6-4-raw')">-100.0<textarea style="position: absolute; left: -9999px;"  id="env-test-6-4-raw">{0: &#39;&#39;, &#39;user0&#39;: &#39;&#39;}</textarea>&#x1f527;<span class="tooltiptext">Not present in target results (-100)<br><a href='#'>Test params differ (click to copy raw value):</a><pre>
+        <td class="status_-2"><div class="tooltip" onclick="elementValueToClipboard('env-test-6-4-raw')">-100.0<textarea style="position: absolute; left: -9999px;"  id="env-test-6-4-raw">{0: &#39;&#39;, &#39;user0&#39;: &#39;&#39;}</textarea>&#x1f527;<span class="tooltiptext">ERROR  Not present in target results (-100) (0; -100) +-1% tolerance<br><a href='#'>Test params differ (click to copy raw value):</a><pre>
 0
 =
 -MISSING IN THIS PARAMS
 user0
 =====
 -MISSING IN THIS PARAMS</pre></span></div></td>
-        <td class="status_-2"><div class="tooltip" onclick="elementValueToClipboard('env-test-6-5-raw')">-100.0<textarea style="position: absolute; left: -9999px;"  id="env-test-6-5-raw">{0: &#39;&#39;, &#39;user0&#39;: &#39;&#39;}</textarea>&#x1f527;<span class="tooltiptext">Not present in target results (-100)<br><a href='#'>Test params differ (click to copy raw value):</a><pre>
+        <td class="status_-2"><div class="tooltip" onclick="elementValueToClipboard('env-test-6-5-raw')">-100.0<textarea style="position: absolute; left: -9999px;"  id="env-test-6-5-raw">{0: &#39;&#39;, &#39;user0&#39;: &#39;&#39;}</textarea>&#x1f527;<span class="tooltiptext">ERROR  Not present in target results (-100) (0; -100) +-1% tolerance<br><a href='#'>Test params differ (click to copy raw value):</a><pre>
 0
 =
 -MISSING IN THIS PARAMS
@@ -12155,28 +12155,28 @@ user0
     </tr>
     <tr class=" status_-2 any_status_-2 any_status_-2 any_status_-2 ">
         <td class="status_Localhost2/fio/0000:./read-64KiB/throughput/iops_sec.mean"><div class="tooltip" onclick="elementValueToClipboard('env-test-7-1-raw')">Localhost2/fio/0000:./read-64KiB/throughput/iops_sec.mean<textarea style="position: absolute; left: -9999px;"  id="env-test-7-1-raw">{0: &#39;benchmark_name:fio\nbs:64k\nclocksource:gettimeofday\ndirect:1\nfilename:/fio\niodepth:32\nioengine:libaio\nlog_avg_msec:1000\nlog_hist_msec:10000\nmax_stddevpct:5\nnumjobs:1\nprimary_metric:iops_sec\nramp_time:5\nruntime:60\nrw:read\nsize:1300000\nsync:0\ntime_based:1\nuid:benchmark_name:%benchmark_name%-controller_host:%controller_host%&#39;, &#39;user0&#39;: &#39;profile: Localhost&#39;}</textarea>&#x1f527;<span class="tooltiptext">Localhost2/fio/0000:./read-64KiB/throughput/iops_sec.mean<br><a href='#'>Click to copy raw src test params</a></span></div></td>
-        <td class="status_-2"><div class="tooltip" onclick="elementValueToClipboard('env-test-7-2-raw')">-100.0<textarea style="position: absolute; left: -9999px;"  id="env-test-7-2-raw">{0: &#39;&#39;, &#39;user0&#39;: &#39;&#39;}</textarea>&#x1f527;<span class="tooltiptext">Not present in target results (-100)<br><a href='#'>Test params differ (click to copy raw value):</a><pre>
+        <td class="status_-2"><div class="tooltip" onclick="elementValueToClipboard('env-test-7-2-raw')">-100.0<textarea style="position: absolute; left: -9999px;"  id="env-test-7-2-raw">{0: &#39;&#39;, &#39;user0&#39;: &#39;&#39;}</textarea>&#x1f527;<span class="tooltiptext">ERROR  Not present in target results (-100) (0; -100) +-1% tolerance<br><a href='#'>Test params differ (click to copy raw value):</a><pre>
 0
 =
 -MISSING IN THIS PARAMS
 user0
 =====
 -MISSING IN THIS PARAMS</pre></span></div></td>
-        <td class="status_-2"><div class="tooltip" onclick="elementValueToClipboard('env-test-7-3-raw')">-100.0<textarea style="position: absolute; left: -9999px;"  id="env-test-7-3-raw">{0: &#39;&#39;, &#39;user0&#39;: &#39;&#39;}</textarea>&#x1f527;<span class="tooltiptext">Not present in target results (-100)<br><a href='#'>Test params differ (click to copy raw value):</a><pre>
+        <td class="status_-2"><div class="tooltip" onclick="elementValueToClipboard('env-test-7-3-raw')">-100.0<textarea style="position: absolute; left: -9999px;"  id="env-test-7-3-raw">{0: &#39;&#39;, &#39;user0&#39;: &#39;&#39;}</textarea>&#x1f527;<span class="tooltiptext">ERROR  Not present in target results (-100) (0; -100) +-1% tolerance<br><a href='#'>Test params differ (click to copy raw value):</a><pre>
 0
 =
 -MISSING IN THIS PARAMS
 user0
 =====
 -MISSING IN THIS PARAMS</pre></span></div></td>
-        <td class="status_-2"><div class="tooltip" onclick="elementValueToClipboard('env-test-7-4-raw')">-100.0<textarea style="position: absolute; left: -9999px;"  id="env-test-7-4-raw">{0: &#39;&#39;, &#39;user0&#39;: &#39;&#39;}</textarea>&#x1f527;<span class="tooltiptext">Not present in target results (-100)<br><a href='#'>Test params differ (click to copy raw value):</a><pre>
+        <td class="status_-2"><div class="tooltip" onclick="elementValueToClipboard('env-test-7-4-raw')">-100.0<textarea style="position: absolute; left: -9999px;"  id="env-test-7-4-raw">{0: &#39;&#39;, &#39;user0&#39;: &#39;&#39;}</textarea>&#x1f527;<span class="tooltiptext">ERROR  Not present in target results (-100) (0; -100) +-1% tolerance<br><a href='#'>Test params differ (click to copy raw value):</a><pre>
 0
 =
 -MISSING IN THIS PARAMS
 user0
 =====
 -MISSING IN THIS PARAMS</pre></span></div></td>
-        <td class="status_-2"><div class="tooltip" onclick="elementValueToClipboard('env-test-7-5-raw')">-100.0<textarea style="position: absolute; left: -9999px;"  id="env-test-7-5-raw">{0: &#39;&#39;, &#39;user0&#39;: &#39;&#39;}</textarea>&#x1f527;<span class="tooltiptext">Not present in target results (-100)<br><a href='#'>Test params differ (click to copy raw value):</a><pre>
+        <td class="status_-2"><div class="tooltip" onclick="elementValueToClipboard('env-test-7-5-raw')">-100.0<textarea style="position: absolute; left: -9999px;"  id="env-test-7-5-raw">{0: &#39;&#39;, &#39;user0&#39;: &#39;&#39;}</textarea>&#x1f527;<span class="tooltiptext">ERROR  Not present in target results (-100) (0; -100) +-1% tolerance<br><a href='#'>Test params differ (click to copy raw value):</a><pre>
 0
 =
 -MISSING IN THIS PARAMS
@@ -12186,28 +12186,28 @@ user0
     </tr>
     <tr class=" status_-2 any_status_-2 any_status_-2 any_status_-2 ">
         <td class="status_Localhost2/fio/0000:./read-64KiB/throughput/iops_sec.stddev"><div class="tooltip" onclick="elementValueToClipboard('env-test-8-1-raw')">Localhost2/fio/0000:./read-64KiB/throughput/iops_sec.stddev<textarea style="position: absolute; left: -9999px;"  id="env-test-8-1-raw">{0: &#39;benchmark_name:fio\nbs:64k\nclocksource:gettimeofday\ndirect:1\nfilename:/fio\niodepth:32\nioengine:libaio\nlog_avg_msec:1000\nlog_hist_msec:10000\nmax_stddevpct:5\nnumjobs:1\nprimary_metric:iops_sec\nramp_time:5\nruntime:60\nrw:read\nsize:1300000\nsync:0\ntime_based:1\nuid:benchmark_name:%benchmark_name%-controller_host:%controller_host%&#39;, &#39;user0&#39;: &#39;profile: Localhost&#39;}</textarea>&#x1f527;<span class="tooltiptext">Localhost2/fio/0000:./read-64KiB/throughput/iops_sec.stddev<br><a href='#'>Click to copy raw src test params</a></span></div></td>
-        <td class="status_-2"><div class="tooltip" onclick="elementValueToClipboard('env-test-8-2-raw')">-100.0<textarea style="position: absolute; left: -9999px;"  id="env-test-8-2-raw">{0: &#39;&#39;, &#39;user0&#39;: &#39;&#39;}</textarea>&#x1f527;<span class="tooltiptext">Not present in target results (-100)<br><a href='#'>Test params differ (click to copy raw value):</a><pre>
+        <td class="status_-2"><div class="tooltip" onclick="elementValueToClipboard('env-test-8-2-raw')">-100.0<textarea style="position: absolute; left: -9999px;"  id="env-test-8-2-raw">{0: &#39;&#39;, &#39;user0&#39;: &#39;&#39;}</textarea>&#x1f527;<span class="tooltiptext">ERROR  Not present in target results (-100) (0; -100) +-1% tolerance<br><a href='#'>Test params differ (click to copy raw value):</a><pre>
 0
 =
 -MISSING IN THIS PARAMS
 user0
 =====
 -MISSING IN THIS PARAMS</pre></span></div></td>
-        <td class="status_-2"><div class="tooltip" onclick="elementValueToClipboard('env-test-8-3-raw')">-100.0<textarea style="position: absolute; left: -9999px;"  id="env-test-8-3-raw">{0: &#39;&#39;, &#39;user0&#39;: &#39;&#39;}</textarea>&#x1f527;<span class="tooltiptext">Not present in target results (-100)<br><a href='#'>Test params differ (click to copy raw value):</a><pre>
+        <td class="status_-2"><div class="tooltip" onclick="elementValueToClipboard('env-test-8-3-raw')">-100.0<textarea style="position: absolute; left: -9999px;"  id="env-test-8-3-raw">{0: &#39;&#39;, &#39;user0&#39;: &#39;&#39;}</textarea>&#x1f527;<span class="tooltiptext">ERROR  Not present in target results (-100) (0; -100) +-1% tolerance<br><a href='#'>Test params differ (click to copy raw value):</a><pre>
 0
 =
 -MISSING IN THIS PARAMS
 user0
 =====
 -MISSING IN THIS PARAMS</pre></span></div></td>
-        <td class="status_-2"><div class="tooltip" onclick="elementValueToClipboard('env-test-8-4-raw')">-100.0<textarea style="position: absolute; left: -9999px;"  id="env-test-8-4-raw">{0: &#39;&#39;, &#39;user0&#39;: &#39;&#39;}</textarea>&#x1f527;<span class="tooltiptext">Not present in target results (-100)<br><a href='#'>Test params differ (click to copy raw value):</a><pre>
+        <td class="status_-2"><div class="tooltip" onclick="elementValueToClipboard('env-test-8-4-raw')">-100.0<textarea style="position: absolute; left: -9999px;"  id="env-test-8-4-raw">{0: &#39;&#39;, &#39;user0&#39;: &#39;&#39;}</textarea>&#x1f527;<span class="tooltiptext">ERROR  Not present in target results (-100) (0; -100) +-1% tolerance<br><a href='#'>Test params differ (click to copy raw value):</a><pre>
 0
 =
 -MISSING IN THIS PARAMS
 user0
 =====
 -MISSING IN THIS PARAMS</pre></span></div></td>
-        <td class="status_-2"><div class="tooltip" onclick="elementValueToClipboard('env-test-8-5-raw')">-100.0<textarea style="position: absolute; left: -9999px;"  id="env-test-8-5-raw">{0: &#39;&#39;, &#39;user0&#39;: &#39;&#39;}</textarea>&#x1f527;<span class="tooltiptext">Not present in target results (-100)<br><a href='#'>Test params differ (click to copy raw value):</a><pre>
+        <td class="status_-2"><div class="tooltip" onclick="elementValueToClipboard('env-test-8-5-raw')">-100.0<textarea style="position: absolute; left: -9999px;"  id="env-test-8-5-raw">{0: &#39;&#39;, &#39;user0&#39;: &#39;&#39;}</textarea>&#x1f527;<span class="tooltiptext">ERROR  Not present in target results (-100) (0; -100) +-1% tolerance<br><a href='#'>Test params differ (click to copy raw value):</a><pre>
 0
 =
 -MISSING IN THIS PARAMS
@@ -12222,7 +12222,7 @@ NA</pre></span></div></td>
 NA</pre></span></div></td>
         <td class="status_-2"><div class="tooltip" onclick="elementValueToClipboard('env-test-9-3-raw')">NA<textarea style="position: absolute; left: -9999px;"  id="env-test-9-3-raw">NA</textarea>&#x1f527;<span class="tooltiptext">Unknown<br><a href='#'>Test params differ (click to copy raw value):</a><pre>
 NA</pre></span></div></td>
-        <td class="status_-2"><div class="tooltip" onclick="elementValueToClipboard('env-test-9-4-raw')">-100.0<textarea style="position: absolute; left: -9999px;"  id="env-test-9-4-raw">{0: &#39;benchmark_name:fio\nbs:4k\nclocksource:gettimeofday\ndirect:1\nfilename:/fio\niodepth:32\nioengine:libaio\nlog_avg_msec:1000\nlog_hist_msec:10000\nmax_stddevpct:5\nnumjobs:1\nprimary_metric:iops_sec\nramp_time:5\nruntime:60\nrw:read\nsize:1300000\nsync:0\ntime_based:1\nuid:benchmark_name:%benchmark_name%-controller_host:%controller_host%&#39;, &#39;user0&#39;: &#39;profile: Localhost&#39;}</textarea>&#x1f527;<span class="tooltiptext">Not present in source results (145825.271186441).<br><a href='#'>Test params differ (click to copy raw value):</a><pre>
+        <td class="status_-2"><div class="tooltip" onclick="elementValueToClipboard('env-test-9-4-raw')">-100.0<textarea style="position: absolute; left: -9999px;"  id="env-test-9-4-raw">{0: &#39;benchmark_name:fio\nbs:4k\nclocksource:gettimeofday\ndirect:1\nfilename:/fio\niodepth:32\nioengine:libaio\nlog_avg_msec:1000\nlog_hist_msec:10000\nmax_stddevpct:5\nnumjobs:1\nprimary_metric:iops_sec\nramp_time:5\nruntime:60\nrw:read\nsize:1300000\nsync:0\ntime_based:1\nuid:benchmark_name:%benchmark_name%-controller_host:%controller_host%&#39;, &#39;user0&#39;: &#39;profile: Localhost&#39;}</textarea>&#x1f527;<span class="tooltiptext">ERROR  Not present in source results (145825.271186441). (0; -100) +-1% tolerance<br><a href='#'>Test params differ (click to copy raw value):</a><pre>
 0
 =
 +MISSING IN SRC
@@ -12239,7 +12239,7 @@ NA</pre></span></div></td>
 NA</pre></span></div></td>
         <td class="status_-2"><div class="tooltip" onclick="elementValueToClipboard('env-test-10-3-raw')">NA<textarea style="position: absolute; left: -9999px;"  id="env-test-10-3-raw">NA</textarea>&#x1f527;<span class="tooltiptext">Unknown<br><a href='#'>Test params differ (click to copy raw value):</a><pre>
 NA</pre></span></div></td>
-        <td class="status_-2"><div class="tooltip" onclick="elementValueToClipboard('env-test-10-4-raw')">-100.0<textarea style="position: absolute; left: -9999px;"  id="env-test-10-4-raw">{0: &#39;benchmark_name:fio\nbs:4k\nclocksource:gettimeofday\ndirect:1\nfilename:/fio\niodepth:32\nioengine:libaio\nlog_avg_msec:1000\nlog_hist_msec:10000\nmax_stddevpct:5\nnumjobs:1\nprimary_metric:iops_sec\nramp_time:5\nruntime:60\nrw:read\nsize:1300000\nsync:0\ntime_based:1\nuid:benchmark_name:%benchmark_name%-controller_host:%controller_host%&#39;, &#39;user0&#39;: &#39;profile: Localhost&#39;}</textarea>&#x1f527;<span class="tooltiptext">Not present in source results (0).<br><a href='#'>Test params differ (click to copy raw value):</a><pre>
+        <td class="status_-2"><div class="tooltip" onclick="elementValueToClipboard('env-test-10-4-raw')">-100.0<textarea style="position: absolute; left: -9999px;"  id="env-test-10-4-raw">{0: &#39;benchmark_name:fio\nbs:4k\nclocksource:gettimeofday\ndirect:1\nfilename:/fio\niodepth:32\nioengine:libaio\nlog_avg_msec:1000\nlog_hist_msec:10000\nmax_stddevpct:5\nnumjobs:1\nprimary_metric:iops_sec\nramp_time:5\nruntime:60\nrw:read\nsize:1300000\nsync:0\ntime_based:1\nuid:benchmark_name:%benchmark_name%-controller_host:%controller_host%&#39;, &#39;user0&#39;: &#39;profile: Localhost&#39;}</textarea>&#x1f527;<span class="tooltiptext">ERROR  Not present in source results (0). (0; -100) +-1% tolerance<br><a href='#'>Test params differ (click to copy raw value):</a><pre>
 0
 =
 +MISSING IN SRC
@@ -12256,7 +12256,7 @@ NA</pre></span></div></td>
 NA</pre></span></div></td>
         <td class="status_-2"><div class="tooltip" onclick="elementValueToClipboard('env-test-11-3-raw')">NA<textarea style="position: absolute; left: -9999px;"  id="env-test-11-3-raw">NA</textarea>&#x1f527;<span class="tooltiptext">Unknown<br><a href='#'>Test params differ (click to copy raw value):</a><pre>
 NA</pre></span></div></td>
-        <td class="status_-2"><div class="tooltip" onclick="elementValueToClipboard('env-test-11-4-raw')">-100.0<textarea style="position: absolute; left: -9999px;"  id="env-test-11-4-raw">{0: &#39;benchmark_name:fio\nbs:64k\nclocksource:gettimeofday\ndirect:1\nfilename:/fio\niodepth:32\nioengine:libaio\nlog_avg_msec:1000\nlog_hist_msec:10000\nmax_stddevpct:5\nnumjobs:1\nprimary_metric:iops_sec\nramp_time:5\nruntime:60\nrw:read\nsize:1300000\nsync:0\ntime_based:1\nuid:benchmark_name:%benchmark_name%-controller_host:%controller_host%&#39;, &#39;user0&#39;: &#39;profile: Localhost&#39;}</textarea>&#x1f527;<span class="tooltiptext">Not present in source results (103140.627118644).<br><a href='#'>Test params differ (click to copy raw value):</a><pre>
+        <td class="status_-2"><div class="tooltip" onclick="elementValueToClipboard('env-test-11-4-raw')">-100.0<textarea style="position: absolute; left: -9999px;"  id="env-test-11-4-raw">{0: &#39;benchmark_name:fio\nbs:64k\nclocksource:gettimeofday\ndirect:1\nfilename:/fio\niodepth:32\nioengine:libaio\nlog_avg_msec:1000\nlog_hist_msec:10000\nmax_stddevpct:5\nnumjobs:1\nprimary_metric:iops_sec\nramp_time:5\nruntime:60\nrw:read\nsize:1300000\nsync:0\ntime_based:1\nuid:benchmark_name:%benchmark_name%-controller_host:%controller_host%&#39;, &#39;user0&#39;: &#39;profile: Localhost&#39;}</textarea>&#x1f527;<span class="tooltiptext">ERROR  Not present in source results (103140.627118644). (0; -100) +-1% tolerance<br><a href='#'>Test params differ (click to copy raw value):</a><pre>
 0
 =
 +MISSING IN SRC
@@ -12273,7 +12273,7 @@ NA</pre></span></div></td>
 NA</pre></span></div></td>
         <td class="status_-2"><div class="tooltip" onclick="elementValueToClipboard('env-test-12-3-raw')">NA<textarea style="position: absolute; left: -9999px;"  id="env-test-12-3-raw">NA</textarea>&#x1f527;<span class="tooltiptext">Unknown<br><a href='#'>Test params differ (click to copy raw value):</a><pre>
 NA</pre></span></div></td>
-        <td class="status_-2"><div class="tooltip" onclick="elementValueToClipboard('env-test-12-4-raw')">-100.0<textarea style="position: absolute; left: -9999px;"  id="env-test-12-4-raw">{0: &#39;benchmark_name:fio\nbs:64k\nclocksource:gettimeofday\ndirect:1\nfilename:/fio\niodepth:32\nioengine:libaio\nlog_avg_msec:1000\nlog_hist_msec:10000\nmax_stddevpct:5\nnumjobs:1\nprimary_metric:iops_sec\nramp_time:5\nruntime:60\nrw:read\nsize:1300000\nsync:0\ntime_based:1\nuid:benchmark_name:%benchmark_name%-controller_host:%controller_host%&#39;, &#39;user0&#39;: &#39;profile: Localhost&#39;}</textarea>&#x1f527;<span class="tooltiptext">Not present in source results (0).<br><a href='#'>Test params differ (click to copy raw value):</a><pre>
+        <td class="status_-2"><div class="tooltip" onclick="elementValueToClipboard('env-test-12-4-raw')">-100.0<textarea style="position: absolute; left: -9999px;"  id="env-test-12-4-raw">{0: &#39;benchmark_name:fio\nbs:64k\nclocksource:gettimeofday\ndirect:1\nfilename:/fio\niodepth:32\nioengine:libaio\nlog_avg_msec:1000\nlog_hist_msec:10000\nmax_stddevpct:5\nnumjobs:1\nprimary_metric:iops_sec\nramp_time:5\nruntime:60\nrw:read\nsize:1300000\nsync:0\ntime_based:1\nuid:benchmark_name:%benchmark_name%-controller_host:%controller_host%&#39;, &#39;user0&#39;: &#39;profile: Localhost&#39;}</textarea>&#x1f527;<span class="tooltiptext">ERROR  Not present in source results (0). (0; -100) +-1% tolerance<br><a href='#'>Test params differ (click to copy raw value):</a><pre>
 0
 =
 +MISSING IN SRC
@@ -12305,22 +12305,22 @@ NA</pre></span></div></td>
                 <li>Not present in 2 out of 4 reference builds</li>
             </ul>
         </li>
-        <li>Localhost2/fio/0000:./read-4KiB/throughput/iops_sec.mean -&gt; Not present in target results (-100)
+        <li>Localhost2/fio/0000:./read-4KiB/throughput/iops_sec.mean -&gt; ERROR  Not present in target results (-100) (0; -100) +-1% tolerance
             <ul>
                 <li>Failed in 4 out of 4 reference builds</li>
             </ul>
         </li>
-        <li>Localhost2/fio/0000:./read-64KiB/throughput/iops_sec.mean -&gt; Not present in target results (-100)
+        <li>Localhost2/fio/0000:./read-64KiB/throughput/iops_sec.mean -&gt; ERROR  Not present in target results (-100) (0; -100) +-1% tolerance
             <ul>
                 <li>Failed in 4 out of 4 reference builds</li>
             </ul>
         </li>
-        <li>Localhost2/fio/0000:./read-4KiB/throughput/iops_sec.stddev -&gt; Not present in target results (-100)
+        <li>Localhost2/fio/0000:./read-4KiB/throughput/iops_sec.stddev -&gt; ERROR  Not present in target results (-100) (0; -100) +-1% tolerance
             <ul>
                 <li>Failed in 4 out of 4 reference builds</li>
             </ul>
         </li>
-        <li>Localhost2/fio/0000:./read-64KiB/throughput/iops_sec.stddev -&gt; Not present in target results (-100)
+        <li>Localhost2/fio/0000:./read-64KiB/throughput/iops_sec.stddev -&gt; ERROR  Not present in target results (-100) (0; -100) +-1% tolerance
             <ul>
                 <li>Failed in 4 out of 4 reference builds</li>
             </ul>

--- a/docs/source/_static/html_result.html
+++ b/docs/source/_static/html_result.html
@@ -10327,7 +10327,7 @@ $(document).ready(function () { chart_overall_mean_cont = new Highcharts.Chart({
         {
             name: 'improvements',
             color: 'gold',
-            data: [[0, 0, 0, 0, 0], [0, 0, 0, 0, 0], [0, 0, 0, 0, 0], [17.27, 17.27, 17.27, 17.27, 17.27]],
+            data: [[0, 0, 0, 0, 0], [0, 0, 0, 0, 0], [0, 0, 0, 0, 0], [13.27, 13.27, 13.27, 13.27, 13.27]],
         },
         {
             name: 'equals',
@@ -10337,7 +10337,7 @@ $(document).ready(function () { chart_overall_mean_cont = new Highcharts.Chart({
         {
             name: 'regressions',
             color: 'red',
-            data: [[-6.75, -6.75, -6.75, -6.75, -6.75], [-6.07, -6.07, -6.07, -6.07, -6.07], [-20.25, -20.25, -20.25, -20.25, -20.25], [-9.61, -9.61, -9.61, -9.61, -9.61]],
+            data: [[-6.75, -6.75, -6.75, -6.75, -6.75], [-6.07, -6.07, -6.07, -6.07, -6.07], [-20.25, -20.25, -20.25, -20.25, -20.25], [-8.4, -8.4, -8.4, -8.4, -8.4]],
         },
     ]
 });});
@@ -10536,7 +10536,7 @@ $(document).ready(function () { chart_Localhost_mean_overall_cont = new Highchar
         {
             name: 'improvements',
             color: 'gold',
-            data: [[0, 0, 0, 0, 0], [0, 0, 0, 0, 0], [0, 0, 0, 0, 0], [17.27, 17.27, 17.27, 17.27, 17.27]],
+            data: [[0, 0, 0, 0, 0], [0, 0, 0, 0, 0], [0, 0, 0, 0, 0], [13.27, 13.27, 13.27, 13.27, 13.27]],
         },
         {
             name: 'equals',
@@ -10546,7 +10546,7 @@ $(document).ready(function () { chart_Localhost_mean_overall_cont = new Highchar
         {
             name: 'regressions',
             color: 'red',
-            data: [[-6.75, -6.75, -6.75, -6.75, -6.75], [-6.07, -6.07, -6.07, -6.07, -6.07], [-20.25, -20.25, -20.25, -20.25, -20.25], [-9.61, -9.61, -9.61, -9.61, -9.61]],
+            data: [[-6.75, -6.75, -6.75, -6.75, -6.75], [-6.07, -6.07, -6.07, -6.07, -6.07], [-20.25, -20.25, -20.25, -20.25, -20.25], [-8.4, -8.4, -8.4, -8.4, -8.4]],
         },
     ]
 });});
@@ -10842,7 +10842,7 @@ $(document).ready(function () { chart_Localhost_fio_iops_sec_mean_overall_cont =
         {
             name: 'improvements',
             color: 'gold',
-            data: [[0, 0, 0, 0, 0], [0, 0, 0, 0, 0], [0, 0, 0, 0, 0], [17.27, 17.27, 17.27, 17.27, 17.27]],
+            data: [[0, 0, 0, 0, 0], [0, 0, 0, 0, 0], [0, 0, 0, 0, 0], [13.27, 13.27, 13.27, 13.27, 13.27]],
         },
         {
             name: 'equals',
@@ -10852,7 +10852,7 @@ $(document).ready(function () { chart_Localhost_fio_iops_sec_mean_overall_cont =
         {
             name: 'regressions',
             color: 'red',
-            data: [[-6.75, -6.75, -6.75, -6.75, -6.75], [-6.07, -6.07, -6.07, -6.07, -6.07], [-20.25, -20.25, -20.25, -20.25, -20.25], [-9.61, -9.61, -9.61, -9.61, -9.61]],
+            data: [[-6.75, -6.75, -6.75, -6.75, -6.75], [-6.07, -6.07, -6.07, -6.07, -6.07], [-20.25, -20.25, -20.25, -20.25, -20.25], [-8.4, -8.4, -8.4, -8.4, -8.4]],
         },
     ]
 });});
@@ -11148,7 +11148,7 @@ $(document).ready(function () { chart_Localhost_fio_read_throughput_iops_sec_mea
         {
             name: 'improvements',
             color: 'gold',
-            data: [[0, 0, 0, 0, 0], [0, 0, 0, 0, 0], [0, 0, 0, 0, 0], [17.27, 17.27, 17.27, 17.27, 17.27]],
+            data: [[0, 0, 0, 0, 0], [0, 0, 0, 0, 0], [0, 0, 0, 0, 0], [13.27, 13.27, 13.27, 13.27, 13.27]],
         },
         {
             name: 'equals',
@@ -11158,7 +11158,7 @@ $(document).ready(function () { chart_Localhost_fio_read_throughput_iops_sec_mea
         {
             name: 'regressions',
             color: 'red',
-            data: [[-6.75, -6.75, -6.75, -6.75, -6.75], [-6.07, -6.07, -6.07, -6.07, -6.07], [-20.25, -20.25, -20.25, -20.25, -20.25], [-9.61, -9.61, -9.61, -9.61, -9.61]],
+            data: [[-6.75, -6.75, -6.75, -6.75, -6.75], [-6.07, -6.07, -6.07, -6.07, -6.07], [-20.25, -20.25, -20.25, -20.25, -20.25], [-8.4, -8.4, -8.4, -8.4, -8.4]],
         },
     ]
 });});
@@ -11976,21 +11976,21 @@ Localhost2/fio/0000:./read-64KiB/throughput/iops_sec.stddev</pre></span></div></
         <td class="status_2"><div class="tooltip">-4.0<span class="tooltiptext">GOOD raw -4.01% (-4.01; -4.005453993002888) +-5.75% tolerance</span></div></td>
         <td class="status_2"><div class="tooltip">-1.1<span class="tooltiptext">GOOD raw -1.07% (-1.07; -1.0650041317484664) +-5.75% tolerance</span></div></td>
         <td class="status_-1"><div class="tooltip">-8.7<span class="tooltiptext">SMALL raw -8.67% (-8.67; -8.667814451256838) +-5.75% tolerance</span></div></td>
-        <td class="status_2"><div class="tooltip">0.2<span class="tooltiptext">GOOD raw 3.83%, avg -4.96% (3.83; 3.827455277150146) +-5.75% tolerance</span></div></td>
+        <td class="status_2"><div class="tooltip">-1.3<span class="tooltiptext">GOOD raw 2.43%, avg -5.65%, n_of -2.11% (2.43; 2.432125293674612) +-5.75% tolerance</span></div></td>
     </tr>
     <tr class=" status_2 any_status_2 any_status_-1 any_status_2 ">
         <td class="status_Localhost/*/*:./*-*/*/*.mean"><div class="tooltip">Localhost/*/*:./*-*/*/*.mean<span class="tooltiptext">Localhost/*/*:./*-*/*/*.mean</span></div></td>
         <td class="status_2"><div class="tooltip">-4.0<span class="tooltiptext">GOOD raw -4.01% (-4.01; -4.005453993002888) +-5.75% tolerance</span></div></td>
         <td class="status_2"><div class="tooltip">-1.1<span class="tooltiptext">GOOD raw -1.07% (-1.07; -1.0650041317484664) +-5.75% tolerance</span></div></td>
         <td class="status_-1"><div class="tooltip">-8.7<span class="tooltiptext">SMALL raw -8.67% (-8.67; -8.667814451256838) +-5.75% tolerance</span></div></td>
-        <td class="status_2"><div class="tooltip">0.2<span class="tooltiptext">GOOD raw 3.83%, avg -4.96% (3.83; 3.827455277150146) +-5.75% tolerance</span></div></td>
+        <td class="status_2"><div class="tooltip">-1.3<span class="tooltiptext">GOOD raw 2.43%, avg -5.65%, n_of -2.11% (2.43; 2.432125293674612) +-5.75% tolerance</span></div></td>
     </tr>
     <tr class=" status_2 any_status_2 any_status_-1 any_status_2 ">
         <td class="status_Localhost/fio/0000:./read-*/throughput/iops_sec.mean"><div class="tooltip">Localhost/fio/0000:./read-*/throughput/iops_sec.mean<span class="tooltiptext">Localhost/fio/0000:./read-*/throughput/iops_sec.mean</span></div></td>
         <td class="status_2"><div class="tooltip">-4.0<span class="tooltiptext">GOOD raw -4.01% (-4.01; -4.005453993002888) +-5.75% tolerance</span></div></td>
         <td class="status_2"><div class="tooltip">-1.1<span class="tooltiptext">GOOD raw -1.07% (-1.07; -1.0650041317484664) +-5.75% tolerance</span></div></td>
         <td class="status_-1"><div class="tooltip">-8.7<span class="tooltiptext">SMALL raw -8.67% (-8.67; -8.667814451256838) +-5.75% tolerance</span></div></td>
-        <td class="status_2"><div class="tooltip">0.2<span class="tooltiptext">GOOD raw 3.83%, avg -4.96% (3.83; 3.827455277150146) +-5.75% tolerance</span></div></td>
+        <td class="status_2"><div class="tooltip">-1.3<span class="tooltiptext">GOOD raw 2.43%, avg -5.65%, n_of -2.11% (2.43; 2.432125293674612) +-5.75% tolerance</span></div></td>
     </tr>
     </table>
 </div>
@@ -12052,7 +12052,7 @@ Localhost2/fio/0000:./read-64KiB/throughput/iops_sec.stddev</pre></span></div></
         <td class="status_2"><div class="tooltip" onclick="elementValueToClipboard('env-test-1-2-raw')">-1.3<span class="tooltiptext">GOOD model0 -1.26%, mraw0 -1.21%, raw -3.57% (179348.46/183743.17; 177181.152542373) +-5.0% tolerance</span></div></td>
         <td class="status_-1"><div class="tooltip" onclick="elementValueToClipboard('env-test-1-3-raw')">-6.1<span class="tooltiptext">SMALL model0 -6.07%, mraw0 -5.63%, raw -7.89% (179348.46/183743.17; 169245.372881356) +-5.0% tolerance</span></div></td>
         <td class="status_-1"><div class="tooltip" onclick="elementValueToClipboard('env-test-1-4-raw')">-20.2<span class="tooltiptext">SMALL model0 -20.25%, mraw0 -18.69%, raw -20.64% (179348.46/183743.17; 145825.271186441) +-5.0% tolerance</span></div></td>
-        <td class="status_-1"><div class="tooltip" onclick="elementValueToClipboard('env-test-1-5-raw')">-9.6<textarea style="position: absolute; left: -9999px;"  id="env-test-1-5-raw">{0: &#39;benchmark_name:fio\nbs:4k\nclocksource:gettimeofday\ndirect:1\nfilename:/fio\niodepth:32\nioengine:libaio\nlog_avg_msec:1000\nlog_hist_msec:10000\nmax_stddevpct:5\nnumjobs:1\nprimary_metric:iops_sec\nramp_time:5\nruntime:61\nrw:read\nsize:1300000\nsync:0\ntime_based:1\nuid:benchmark_name:%benchmark_name%-controller_host:%controller_host%&#39;, &#39;user0&#39;: &#39;profile: Localhost&#39;}</textarea>&#x1f527;<span class="tooltiptext">SMALL raw -6.83%, avg -16.23% GOOD model0 -4.88%, mraw0 -4.54% (179348.46/183743.17; 171197.389830508) +-5.0% tolerance<br><a href='#'>Test params differ (click to copy raw value):</a><pre>
+        <td class="status_-1"><div class="tooltip" onclick="elementValueToClipboard('env-test-1-5-raw')">-8.4<textarea style="position: absolute; left: -9999px;"  id="env-test-1-5-raw">{0: &#39;benchmark_name:fio\nbs:4k\nclocksource:gettimeofday\ndirect:1\nfilename:/fio\niodepth:32\nioengine:libaio\nlog_avg_msec:1000\nlog_hist_msec:10000\nmax_stddevpct:5\nnumjobs:1\nprimary_metric:iops_sec\nramp_time:5\nruntime:61\nrw:read\nsize:1300000\nsync:0\ntime_based:1\nuid:benchmark_name:%benchmark_name%-controller_host:%controller_host%&#39;, &#39;user0&#39;: &#39;profile: Localhost&#39;}</textarea>&#x1f527;<span class="tooltiptext">SMALL raw -6.83%, avg -16.23%, n_of -5.50% GOOD model0 -4.88%, mraw0 -4.54% (179348.46/183743.17; 171197.389830508) +-5.0% tolerance<br><a href='#'>Test params differ (click to copy raw value):</a><pre>
 0
 =
 -runtime:60
@@ -12063,7 +12063,7 @@ Localhost2/fio/0000:./read-64KiB/throughput/iops_sec.stddev</pre></span></div></
         <td class="status_2"><div class="tooltip" onclick="elementValueToClipboard('env-test-2-2-raw')">0.0<span class="tooltiptext">GOOD raw 0.00% (0; 0) +-10.0% tolerance</span></div></td>
         <td class="status_2"><div class="tooltip" onclick="elementValueToClipboard('env-test-2-3-raw')">0.0<span class="tooltiptext">GOOD raw 0.00% (0; 0) +-10.0% tolerance</span></div></td>
         <td class="status_2"><div class="tooltip" onclick="elementValueToClipboard('env-test-2-4-raw')">0.0<span class="tooltiptext">GOOD raw 0.00% (0; 0) +-10.0% tolerance</span></div></td>
-        <td class="status_2"><div class="tooltip" onclick="elementValueToClipboard('env-test-2-5-raw')">0.0<textarea style="position: absolute; left: -9999px;"  id="env-test-2-5-raw">{0: &#39;benchmark_name:fio\nbs:4k\nclocksource:gettimeofday\ndirect:1\nfilename:/fio\niodepth:32\nioengine:libaio\nlog_avg_msec:1000\nlog_hist_msec:10000\nmax_stddevpct:5\nnumjobs:1\nprimary_metric:iops_sec\nramp_time:5\nruntime:61\nrw:read\nsize:1300000\nsync:0\ntime_based:1\nuid:benchmark_name:%benchmark_name%-controller_host:%controller_host%&#39;, &#39;user0&#39;: &#39;profile: Localhost&#39;}</textarea>&#x1f527;<span class="tooltiptext">GOOD raw 0.00%, avg 0.00% (0; 0) +-10.0% tolerance<br><a href='#'>Test params differ (click to copy raw value):</a><pre>
+        <td class="status_2"><div class="tooltip" onclick="elementValueToClipboard('env-test-2-5-raw')">0.0<textarea style="position: absolute; left: -9999px;"  id="env-test-2-5-raw">{0: &#39;benchmark_name:fio\nbs:4k\nclocksource:gettimeofday\ndirect:1\nfilename:/fio\niodepth:32\nioengine:libaio\nlog_avg_msec:1000\nlog_hist_msec:10000\nmax_stddevpct:5\nnumjobs:1\nprimary_metric:iops_sec\nramp_time:5\nruntime:61\nrw:read\nsize:1300000\nsync:0\ntime_based:1\nuid:benchmark_name:%benchmark_name%-controller_host:%controller_host%&#39;, &#39;user0&#39;: &#39;profile: Localhost&#39;}</textarea>&#x1f527;<span class="tooltiptext">GOOD raw 0.00%, avg 0.00%, n_of -0.00% (0; 0) +-10.0% tolerance<br><a href='#'>Test params differ (click to copy raw value):</a><pre>
 0
 =
 -runtime:60
@@ -12074,7 +12074,7 @@ Localhost2/fio/0000:./read-64KiB/throughput/iops_sec.stddev</pre></span></div></
         <td class="status_-1"><div class="tooltip" onclick="elementValueToClipboard('env-test-3-2-raw')">-6.8<span class="tooltiptext">SMALL model0 -6.75%, mraw0 -6.14%, raw -8.70% (100482.88/103308.03; 94316.7627118644) +-5.0% tolerance</span></div></td>
         <td class="status_1"><div class="tooltip" onclick="elementValueToClipboard('env-test-3-3-raw')">3.9<span class="tooltiptext">GOOD model0 3.94%, mraw0 3.58%, raw 0.75% (100482.88/103308.03; 104077.847457627) +-5.0% tolerance</span></div></td>
         <td class="status_1"><div class="tooltip" onclick="elementValueToClipboard('env-test-3-4-raw')">2.9<span class="tooltiptext">GOOD model0 2.91%, mraw0 2.64%, raw -0.16% (100482.88/103308.03; 103140.627118644) +-5.0% tolerance</span></div></td>
-        <td class="status_-3"><div class="tooltip" onclick="elementValueToClipboard('env-test-3-5-raw')">17.3<textarea style="position: absolute; left: -9999px;"  id="env-test-3-5-raw">{0: &#39;benchmark_name:fio\nbs:64k\nclocksource:gettimeofday\ndirect:1\nfilename:/fio\niodepth:32\nioengine:libaio\nlog_avg_msec:1000\nlog_hist_msec:10000\nmax_stddevpct:5\nnumjobs:1\nprimary_metric:iops_sec\nramp_time:5\nruntime:61\nrw:read\nsize:1300000\nsync:0\ntime_based:1\nuid:benchmark_name:%benchmark_name%-controller_host:%controller_host%&#39;, &#39;user0&#39;: &#39;profile: Localhost&#39;}</textarea>&#x1f527;<span class="tooltiptext">BIG model0 21.78%, mraw0 19.80%, raw 16.53%, avg 10.94% (100482.88/103308.03; 120381.830508475) +-5.0% tolerance<br><a href='#'>Test params differ (click to copy raw value):</a><pre>
+        <td class="status_-3"><div class="tooltip" onclick="elementValueToClipboard('env-test-3-5-raw')">13.3<textarea style="position: absolute; left: -9999px;"  id="env-test-3-5-raw">{0: &#39;benchmark_name:fio\nbs:64k\nclocksource:gettimeofday\ndirect:1\nfilename:/fio\niodepth:32\nioengine:libaio\nlog_avg_msec:1000\nlog_hist_msec:10000\nmax_stddevpct:5\nnumjobs:1\nprimary_metric:iops_sec\nramp_time:5\nruntime:61\nrw:read\nsize:1300000\nsync:0\ntime_based:1\nuid:benchmark_name:%benchmark_name%-controller_host:%controller_host%&#39;, &#39;user0&#39;: &#39;profile: Localhost&#39;}</textarea>&#x1f527;<span class="tooltiptext">BIG model0 21.78%, mraw0 19.80%, raw 16.53%, avg 10.94% GOOD n_of 3.67% (100482.88/103308.03; 120381.830508475) +-5.0% tolerance<br><a href='#'>Test params differ (click to copy raw value):</a><pre>
 0
 =
 -runtime:60
@@ -12085,7 +12085,7 @@ Localhost2/fio/0000:./read-64KiB/throughput/iops_sec.stddev</pre></span></div></
         <td class="status_2"><div class="tooltip" onclick="elementValueToClipboard('env-test-4-2-raw')">0.0<span class="tooltiptext">GOOD raw 0.00% (0; 0) +-10.0% tolerance</span></div></td>
         <td class="status_2"><div class="tooltip" onclick="elementValueToClipboard('env-test-4-3-raw')">0.0<span class="tooltiptext">GOOD raw 0.00% (0; 0) +-10.0% tolerance</span></div></td>
         <td class="status_2"><div class="tooltip" onclick="elementValueToClipboard('env-test-4-4-raw')">0.0<span class="tooltiptext">GOOD raw 0.00% (0; 0) +-10.0% tolerance</span></div></td>
-        <td class="status_2"><div class="tooltip" onclick="elementValueToClipboard('env-test-4-5-raw')">0.0<textarea style="position: absolute; left: -9999px;"  id="env-test-4-5-raw">{0: &#39;benchmark_name:fio\nbs:64k\nclocksource:gettimeofday\ndirect:1\nfilename:/fio\niodepth:32\nioengine:libaio\nlog_avg_msec:1000\nlog_hist_msec:10000\nmax_stddevpct:5\nnumjobs:1\nprimary_metric:iops_sec\nramp_time:5\nruntime:61\nrw:read\nsize:1300000\nsync:0\ntime_based:1\nuid:benchmark_name:%benchmark_name%-controller_host:%controller_host%&#39;, &#39;user0&#39;: &#39;profile: Localhost&#39;}</textarea>&#x1f527;<span class="tooltiptext">GOOD raw 0.00%, avg 0.00% (0; 0) +-10.0% tolerance<br><a href='#'>Test params differ (click to copy raw value):</a><pre>
+        <td class="status_2"><div class="tooltip" onclick="elementValueToClipboard('env-test-4-5-raw')">0.0<textarea style="position: absolute; left: -9999px;"  id="env-test-4-5-raw">{0: &#39;benchmark_name:fio\nbs:64k\nclocksource:gettimeofday\ndirect:1\nfilename:/fio\niodepth:32\nioengine:libaio\nlog_avg_msec:1000\nlog_hist_msec:10000\nmax_stddevpct:5\nnumjobs:1\nprimary_metric:iops_sec\nramp_time:5\nruntime:61\nrw:read\nsize:1300000\nsync:0\ntime_based:1\nuid:benchmark_name:%benchmark_name%-controller_host:%controller_host%&#39;, &#39;user0&#39;: &#39;profile: Localhost&#39;}</textarea>&#x1f527;<span class="tooltiptext">GOOD raw 0.00%, avg 0.00%, n_of -0.00% (0; 0) +-10.0% tolerance<br><a href='#'>Test params differ (click to copy raw value):</a><pre>
 0
 =
 -runtime:60
@@ -12293,13 +12293,13 @@ NA</pre></span></div></td>
     <div>List of build <a href="Unknown">10
 </a> failures:</div>
     <ul>
-        <li>Localhost/fio/0000:./read-4KiB/throughput/iops_sec.mean -&gt; SMALL raw -6.83%, avg -16.23% GOOD model0 -4.88%, mraw0 -4.54% (179348.46/183743.17; 171197.389830508) +-5.0% tolerance
+        <li>Localhost/fio/0000:./read-4KiB/throughput/iops_sec.mean -&gt; SMALL raw -6.83%, avg -16.23%, n_of -5.50% GOOD model0 -4.88%, mraw0 -4.54% (179348.46/183743.17; 171197.389830508) +-5.0% tolerance
             <ul>
                 <li>Failed in 3 out of 4 reference builds</li>
                 <li>Not present in 1 out of 4 reference builds</li>
             </ul>
         </li>
-        <li>Localhost/fio/0000:./read-64KiB/throughput/iops_sec.mean -&gt; BIG model0 21.78%, mraw0 19.80%, raw 16.53%, avg 10.94% (100482.88/103308.03; 120381.830508475) +-5.0% tolerance
+        <li>Localhost/fio/0000:./read-64KiB/throughput/iops_sec.mean -&gt; BIG model0 21.78%, mraw0 19.80%, raw 16.53%, avg 10.94% GOOD n_of 3.67% (100482.88/103308.03; 120381.830508475) +-5.0% tolerance
             <ul>
                 <li>Failed in 2 out of 4 reference builds</li>
                 <li>Not present in 2 out of 4 reference builds</li>

--- a/runperf/__init__.py
+++ b/runperf/__init__.py
@@ -407,7 +407,7 @@ class ComparePerf:
                             "weight of this model. Note the weight might be "
                             "adjusted based on the number of builds "
                             "(when no builds < 8) [%(default)s]", type=float,
-                            default=1)
+                            default=0)
         parser.add_argument("--model-linear-regression", "-l", help="Use "
                             "linear regression model for matching results",
                             nargs='+', default=[])

--- a/runperf/__init__.py
+++ b/runperf/__init__.py
@@ -411,6 +411,12 @@ class ComparePerf:
         parser.add_argument("--model-linear-regression", "-l", help="Use "
                             "linear regression model for matching results",
                             nargs='+', default=[])
+        parser.add_argument("--n-out-of-results", help="Weight of the "
+                            "check that looks at how many times each test "
+                            "failed within reference builds.",
+                            type=float, default=0)
+        parser.add_argument("--n-out-of-results-n", help="How many builds "
+                            "can fail to report PASS", type=int, default=2)
         parser.add_argument("--html", help="Create a single-file HTML report "
                             "in the provided path.")
         parser.add_argument("--html-with-charts", action="store_true",
@@ -434,6 +440,10 @@ class ComparePerf:
         if args.model_builds_average:
             modifiers.append(result.AveragesModifier(
                 args.model_builds_average))
+        if args.n_out_of_results:
+            modifiers.append(result.NOutOfResultsModifier(
+                args.n_out_of_results,
+                args.n_out_of_results_n))
         results = result.ResultsContainer(self.log, args.tolerance,
                                           args.stddev_tolerance,
                                           args.model_builds_average,

--- a/runperf/__init__.py
+++ b/runperf/__init__.py
@@ -425,17 +425,22 @@ class ComparePerf:
         args = parser.parse_args()
         setup_logging(args.verbose, "%(levelname)-5s| %(message)s")
         models = []
+        modifiers = []
         for path in args.model_linear_regression:
             model = result.ModelLinearRegression(args.tolerance,
                                                  args.stddev_tolerance,
                                                  path)
             models.append(model)
+        if args.model_builds_average:
+            modifiers.append(result.AveragesModifier(
+                args.model_builds_average))
         results = result.ResultsContainer(self.log, args.tolerance,
                                           args.stddev_tolerance,
                                           args.model_builds_average,
                                           models,
                                           args.results[0][0],
-                                          args.results[0][1])
+                                          args.results[0][1],
+                                          modifiers)
         skip_incorrect = not args.include_incorrect_results
         for name, path in args.results[1:-1]:
             res = results.add_result_by_path(name, path,

--- a/selftests/.assets/results/result.xunit
+++ b/selftests/.assets/results/result.xunit
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuite name="runperf" timestamp="FILTERED" tests="32" errors="4" failures="1" skipped="1" time="0.000">
 	<testcase classname="Localhost/fio/0000:./read-4KiB/throughput" name="iops_sec.mean" time="0.000">
-		<failure type="failure" message="SMALL raw -6.83%, avg -16.23% GOOD model0 -4.88%, mraw0 -4.54% (179348.46/183743.17; 171197.389830508) +-5.0% tolerance"/>
+		<failure type="failure" message="SMALL raw -6.83%, avg -16.23%, n_of -5.50% GOOD model0 -4.88%, mraw0 -4.54% (179348.46/183743.17; 171197.389830508) +-5.0% tolerance"/>
 	</testcase>
 	<testcase classname="Localhost/fio/0000:./read-4KiB/throughput" name="iops_sec.stddev" time="0.000"/>
 	<testcase classname="Localhost/fio/0000:./read-64KiB/throughput" name="iops_sec.mean" time="0.000">
-		<skipped type="skipped" message="BIG model0 21.78%, mraw0 19.80%, raw 16.53%, avg 10.94% (100482.88/103308.03; 120381.830508475) +-5.0% tolerance"/>
+		<skipped type="skipped" message="BIG model0 21.78%, mraw0 19.80%, raw 16.53%, avg 10.94% GOOD n_of 3.67% (100482.88/103308.03; 120381.830508475) +-5.0% tolerance"/>
 	</testcase>
 	<testcase classname="Localhost/fio/0000:./read-64KiB/throughput" name="iops_sec.stddev" time="0.000"/>
 	<testcase classname="Localhost2/fio/0000:./read-4KiB/throughput" name="iops_sec.mean" time="0.000">

--- a/selftests/.assets/results/result.xunit
+++ b/selftests/.assets/results/result.xunit
@@ -9,15 +9,15 @@
 	</testcase>
 	<testcase classname="Localhost/fio/0000:./read-64KiB/throughput" name="iops_sec.stddev" time="0.000"/>
 	<testcase classname="Localhost2/fio/0000:./read-4KiB/throughput" name="iops_sec.mean" time="0.000">
-		<error type="error" message="Not present in target results (-100)"/>
+		<error type="error" message="ERROR  Not present in target results (-100) (0; -100) +-1% tolerance"/>
 	</testcase>
 	<testcase classname="Localhost2/fio/0000:./read-4KiB/throughput" name="iops_sec.stddev" time="0.000">
-		<error type="error" message="Not present in target results (-100)"/>
+		<error type="error" message="ERROR  Not present in target results (-100) (0; -100) +-1% tolerance"/>
 	</testcase>
 	<testcase classname="Localhost2/fio/0000:./read-64KiB/throughput" name="iops_sec.mean" time="0.000">
-		<error type="error" message="Not present in target results (-100)"/>
+		<error type="error" message="ERROR  Not present in target results (-100) (0; -100) +-1% tolerance"/>
 	</testcase>
 	<testcase classname="Localhost2/fio/0000:./read-64KiB/throughput" name="iops_sec.stddev" time="0.000">
-		<error type="error" message="Not present in target results (-100)"/>
+		<error type="error" message="ERROR  Not present in target results (-100) (0; -100) +-1% tolerance"/>
 	</testcase>
 </testsuite>

--- a/selftests/core/test_compareperf.py
+++ b/selftests/core/test_compareperf.py
@@ -61,8 +61,8 @@ class RunPerfTest(Selftest):
         args = ["compare-perf", "--html-with-charts",
                 "--tolerance", "5", "--stddev-tolerance", "10",
                 "--model-linear-regression", model_path,
-                "--html", html_path, "--xunit", xunit_path,
-                "--"]
+                "--model-builds-average", "1", "--html", html_path,
+                "--xunit", xunit_path, "--"]
         self.assertEqual(self._run(args + results, self.base_dir), 2)
         with open(os.path.join(self.base_dir, "docs", "source", "_static",
                                "html_result.html")) as exp:

--- a/selftests/core/test_compareperf.py
+++ b/selftests/core/test_compareperf.py
@@ -61,8 +61,8 @@ class RunPerfTest(Selftest):
         args = ["compare-perf", "--html-with-charts",
                 "--tolerance", "5", "--stddev-tolerance", "10",
                 "--model-linear-regression", model_path,
-                "--model-builds-average", "1", "--html", html_path,
-                "--xunit", xunit_path, "--"]
+                "--model-builds-average", "1", "--n-out-of-results", "1",
+                "--html", html_path, "--xunit", xunit_path, "--"]
         self.assertEqual(self._run(args + results, self.base_dir), 2)
         with open(os.path.join(self.base_dir, "docs", "source", "_static",
                                "html_result.html")) as exp:


### PR DESCRIPTION
This PR refactors how average model was hacked-in into a proper feature and uses this API to implement a new n-out-of-results mod, which allows one to wait for more builds to fail before declaring the results broken.