### PR TITLE
Fix the pbench tools path in register_tools

### DIFF
--- a/runperf/utils/pbench.py
+++ b/runperf/utils/pbench.py
@@ -145,8 +145,7 @@ def register_tools(session, tools, clients):
     # Cleanup previous tools configuration
     for client in clients:
         with client.get_session_cont() as csession:
-            csession.cmd_output("rm -rf /var/lib/libvirt/pbench-agent/"
-                                "tools-default")
+            csession.cmd_output("rm -rf /var/lib/pbench-agent/tools-default")
     # Register tools on all clients
     addrs = ','.join(_.get_addr() for _ in clients)
     for tool in tools:


### PR DESCRIPTION
there was a typo and the dir we were trying to clean is not related to
pbench tools at all.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>