### PR TITLE
Print test-start message to all workers dmesg's

### DIFF
--- a/selftests/core/test_runperf.py
+++ b/selftests/core/test_runperf.py
@@ -109,7 +109,9 @@ class RunPerfTest(Selftest):
                                                                         dst)):
                             with mock.patch("runperf.machine.Controller."
                                             "fetch_logs"):
-                                main()
+                                with mock.patch("runperf.tests.BaseTest"
+                                                "._all_machines_kmsg"):
+                                    main()
         # Check only for test dirs, metadata are checked in other tests
         self.assertTrue(os.path.exists(os.path.join(self.tmpdir, "result")))
         for serial in ["0000", "0001"]:


### PR DESCRIPTION
In order to simplify synchronizing logs across multiple machines let's
print a dmesg message on all of them when we start the test along with
the current controller's time.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>