### PR TITLE
Ignore failures when logging test to kmsg

### DIFF
--- a/runperf/tests.py
+++ b/runperf/tests.py
@@ -51,10 +51,10 @@ class BaseTest:
         for workers in self.workers:
             for worker in workers:
                 with worker.get_session_cont(hop=self.host) as session:
-                    session.cmd(utils.shell_write_content_cmd("/dev/kmsg",
-                                                              msg))
+                    session.cmd_status(
+                        utils.shell_write_content_cmd("/dev/kmsg", msg))
         with self.host.get_session_cont(hop=self.host) as session:
-            session.cmd(utils.shell_write_content_cmd("/dev/kmsg", msg))
+            session.cmd_status(utils.shell_write_content_cmd("/dev/kmsg", msg))
 
     def run(self):
         """Run the testing"""


### PR DESCRIPTION
avoid failing the test in case writing to kmsg fails as it is not really
critical.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>