### PR TITLE
Remove all tools-*default pbench dirs on refresh

### DIFF
--- a/runperf/profiles.py
+++ b/runperf/profiles.py
@@ -12,7 +12,6 @@
 #
 # Copyright: Red Hat Inc. 2018
 # Author: Lukas Doktor <ldoktor@redhat.com>
-import glob
 import logging
 import os
 import time

--- a/runperf/utils/pbench.py
+++ b/runperf/utils/pbench.py
@@ -147,7 +147,7 @@ def register_tools(session, tools, clients):
     # Cleanup previous tools configuration
     for client in clients:
         with client.get_session_cont() as csession:
-            csession.cmd_output("rm -rf /var/lib/pbench-agent/tools-default")
+            csession.cmd_output("rm -rf /var/lib/pbench-agent/tools-*default")
     # Register tools on all clients
     addrs = ','.join(_.get_addr() for _ in clients)
     for tool in tools:


### PR DESCRIPTION
The pbench-71.x uses "tools-v1-default" directory name to store the list
of registered tools, let's delete all of them.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>