### PR TITLE
Use "pbench-clear-tools" to unregister tools

### DIFF
--- a/runperf/utils/pbench.py
+++ b/runperf/utils/pbench.py
@@ -145,9 +145,7 @@ def register_tools(session, tools, clients):
     Unregister all tools and then register the provided ones
     """
     # Cleanup previous tools configuration
-    for client in clients:
-        with client.get_session_cont() as csession:
-            csession.cmd_output("rm -rf /var/lib/pbench-agent/tools-*default")
+    session.cmd("pbench-clear-tools")
     # Register tools on all clients
     addrs = ','.join(_.get_addr() for _ in clients)
     for tool in tools:

--- a/selftests/core/test_tests.py
+++ b/selftests/core/test_tests.py
@@ -52,7 +52,6 @@ class PBenchTest(Selftest):
                          args)
         mock_args = {'cmd_status.return_value': 0,
                      'cmd_output.side_effect': (
-                         [0] +
                          prepend_host_cmd_output_side_effect +
                          ["prefix+self._cmd", "0", result_path]),
                      'cmd_status_output.return_value': [1, ""]}


### PR DESCRIPTION
The "pbench-clear-tools" should unregister the tools from all clients.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>