### PR TITLE
Add support to override test/profile names

### DIFF
--- a/docs/source/scripts.rst
+++ b/docs/source/scripts.rst
@@ -78,6 +78,10 @@ Profiles
 Are implemented under :mod:`runperf.profiles` and they can accept
 additional parameters. See each profile API documentation for details.
 
+By default profiles are named according to their class but one can
+tweak the name (and result dir) by using ``"__NAME__": "custom name"``
+extra argument.
+
 There is one shared extra parameter available for all profiles,
 the `RUNPERF_TESTS`, which allows to override/extend the set of tests
 that will be executed on this profile. Similarly to ``--tests`` one
@@ -130,6 +134,10 @@ of a few `pbench-based <https://distributed-system-analysis.github.io/pbench/pbe
 tests. These tests accept any extra argument (specified via
 'TestName:{"arg": "val"}') on the cmdline and pass it directly to the
 pbench-$test command. Below you can find all/most arguments that can be tweaked.
+
+By default tests are named according to their class but one can
+tweak the name (and result dir) by using ``"__NAME__": "custom name"``
+extra argument.
 
 In case you want to use the number of cpus per worker you can supply
 ``__PER_WORKER_CPUS__`` value which will be calculated and replaced

--- a/runperf/profiles.py
+++ b/runperf/profiles.py
@@ -46,6 +46,9 @@ class BaseProfile:
         self.session = host.get_session()
         self.rp_paths = rp_paths
         self.extra = extra
+        name = extra.get("__NAME__")
+        if name:
+            self.name = utils.string_to_safe_path(name)
         # List of available workers
         self.workers = []
         self.log_fetcher = utils.LogFetcher()

--- a/runperf/tests.py
+++ b/runperf/tests.py
@@ -37,6 +37,9 @@ class BaseTest:
             os.makedirs(base_output_path)
         self.output = tempfile.mkdtemp(prefix="tmp", dir=base_output_path)
         self.metadata = metadata
+        name = extra.get("__NAME__")
+        if name:
+            self.name = utils.string_to_safe_path(name)
 
     def setup(self):
         """

--- a/selftests/core/test_profiles.py
+++ b/selftests/core/test_profiles.py
@@ -161,6 +161,16 @@ class ProfileUnitTests(Selftest):
                                             None, setup_script_path)
             self.assertEqual(None, out)
 
+    def test_name(self):
+        profile = profiles.Localhost(mock.Mock(), None, {})
+        self.assertEqual("Localhost", profile.name)
+        profile = profiles.Localhost(mock.Mock(), None,
+                                     {"__NAME__": "Custom name"})
+        self.assertEqual("Custom name", profile.name)
+        profile = profiles.Localhost(mock.Mock(), None,
+                                     {"__NAME__": "Custom/name"})
+        self.assertEqual("Custom_name", profile.name)
+
 
 class RunPerfTest(Selftest):
 

--- a/selftests/core/test_tests.py
+++ b/selftests/core/test_tests.py
@@ -140,6 +140,16 @@ class PBenchTest(Selftest):
                    "--linpack-binary='/my/path/to/linpack'",
                    ["/my/path/to/linpack"])
 
+    def test_custom_name(self):
+        tst = tests.DummyTest(None, None, self.tmpdir, {}, {})
+        self.assertEqual(tst.name, "DummyTest")
+        tst = tests.DummyTest(None, None, self.tmpdir, {},
+                              {"__NAME__": "Custom name"})
+        self.assertEqual(tst.name, "Custom name")
+        tst = tests.DummyTest(None, None, self.tmpdir, {},
+                              {"__NAME__": "Custom/name"})
+        self.assertEqual(tst.name, "Custom_name")
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
By default test/profile names are given by the class name. Frequently we
might want to override these to simplify postprocessing or report names.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>