### PR TITLE
Ignore "__" extra variables in pbench tests

### DIFF
--- a/runperf/tests.py
+++ b/runperf/tests.py
@@ -166,6 +166,9 @@ class PBenchTest(BaseTest):
         # Using sorted to always use the same cmdline
         for key, value in sorted(extra.items()):
             # Replace special values
+            # Skip "__*" keys
+            if key.startswith("__"):
+                continue
             # __PER_WORKER_CPUS__ == no cpus perf worker
             if value == "__PER_WORKER_CPUS__":
                 for _workers in self.workers:

--- a/selftests/core/test_tests.py
+++ b/selftests/core/test_tests.py
@@ -99,7 +99,8 @@ class PBenchTest(Selftest):
     def test_fio_custom(self):
         self.check(tests.PBenchFio, {"pbench_server_publish": "yes",
                                      "project": "asdf", "build": "fdsa"},
-                   {"test-types": "randomrw", "runtime": "10", "foo": "bar"},
+                   {"test-types": "randomrw", "runtime": "10", "foo": "bar",
+                    "__THIS_WONT_BE_INCLUDED__": "value"},
                    'pbench-fio  --foo=bar --ramptime=10 --runtime=10 '
                    '--samples=3 --test-types=randomrw --clients=addr2')
 


### PR DESCRIPTION
The pbench tests accept any extra variables and turn them into pbench
call arguments, which clashes with the "__NAME__" option. Let's skip all
"__" prefixed options.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>