### PR TITLE
Fix custom test/profile name handling

### DIFF
--- a/runperf/__init__.py
+++ b/runperf/__init__.py
@@ -301,7 +301,7 @@ def main():
                 continue
 
             # Run all tests under current profile
-            profile_path = os.path.join(args.output, profile)
+            profile_path = os.path.join(args.output, hosts.profile)
             for test, extra in test_defs:
                 for i in range(args.retry_tests):
                     try:
@@ -309,20 +309,21 @@ def main():
                         break
                     except (AssertionError, aexpect.ExpectError,
                             aexpect.ShellError, RuntimeError) as details:
-                        msg = (f"test {test.test}@{profile} attempt {i} "
+                        msg = (f"test {test.test}@{hosts.profile} attempt {i} "
                                f"execution failure: {details}")
                         utils.record_failure(os.path.join(profile_path,
                                                           test.test, str(i)),
                                              details, details=msg)
                 else:
                     log.error("ERROR running %s@%s, test will be SKIPPED!",
-                              test.test, profile)
+                              test.test, hosts.profile)
             # Fetch logs
             try:
-                hosts.fetch_logs(os.path.join(args.output, profile,
+                hosts.fetch_logs(os.path.join(args.output, hosts.profile,
                                               '__sysinfo__'))
             except Exception as exc:    # pylint: disable=W0703
-                utils.record_failure(os.path.join(args.output, profile), exc)
+                utils.record_failure(os.path.join(args.output, hosts.profile),
+                                     exc)
             # Revert profile changes. In case manual reboot is required return
             # non-zero.
             hosts.revert_profile()

--- a/runperf/machine.py
+++ b/runperf/machine.py
@@ -460,11 +460,11 @@ class Controller:
                            controller
         :param workers: list of workers to be made available for execution
         """
-        name = test_class.name
-        self.log.info(f"  RUN test {name}")
         test = test_class(self.main_host, workers,
-                          os.path.join(self._output_dir, self.profile,
-                                       name), self.metadata, extra)
+                          os.path.join(self._output_dir, self.profile),
+                          self.metadata, extra)
+        name = test.name
+        self.log.info(f"  RUN test {name}")
         try:
             test.setup()
             test.run()

--- a/runperf/tests.py
+++ b/runperf/tests.py
@@ -29,17 +29,18 @@ class BaseTest:
     name = ""
     min_groups = 1
 
-    def __init__(self, host, workers, base_output_path,
-                 metadata, extra):  # pylint: disable=W0613
+    def __init__(self, host, workers, base_output_path, metadata, extra):
+        name = extra.pop('__NAME__', None)
+        if not name:
+            name = self.name
+        self.name = utils.string_to_safe_path(name)
         self.host = host
         self.workers = workers
+        base_output_path = os.path.join(base_output_path, self.name)
         if not os.path.exists(base_output_path):
             os.makedirs(base_output_path)
         self.output = tempfile.mkdtemp(prefix="tmp", dir=base_output_path)
         self.metadata = metadata
-        name = extra.get("__NAME__")
-        if name:
-            self.name = utils.string_to_safe_path(name)
 
     def setup(self):
         """

--- a/selftests/core/test_tests.py
+++ b/selftests/core/test_tests.py
@@ -142,14 +142,27 @@ class PBenchTest(Selftest):
                    ["/my/path/to/linpack"])
 
     def test_custom_name(self):
+        shutil.rmtree(self.tmpdir)
         tst = tests.DummyTest(None, None, self.tmpdir, {}, {})
         self.assertEqual(tst.name, "DummyTest")
+        self.assertTrue(os.path.exists(os.path.join(self.tmpdir, "DummyTest")),
+                        os.listdir(self.tmpdir))
+        shutil.rmtree(self.tmpdir)
         tst = tests.DummyTest(None, None, self.tmpdir, {},
                               {"__NAME__": "Custom name"})
         self.assertEqual(tst.name, "Custom name")
+        self.assertFalse(os.path.exists(os.path.join(
+            self.tmpdir, "DummyTest")), os.listdir(self.tmpdir))
+        self.assertTrue(os.path.exists(os.path.join(
+            self.tmpdir, "Custom name")), os.listdir(self.tmpdir))
+        shutil.rmtree(self.tmpdir)
         tst = tests.DummyTest(None, None, self.tmpdir, {},
                               {"__NAME__": "Custom/name"})
         self.assertEqual(tst.name, "Custom_name")
+        self.assertFalse(os.path.exists(os.path.join(
+            self.tmpdir, "DummyTest")), os.listdir(self.tmpdir))
+        self.assertTrue(os.path.exists(os.path.join(
+            self.tmpdir, "Custom_name")), os.listdir(self.tmpdir))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Refactor the test/profile name handling in order to reflect the name
changes during __init__.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>