### PR TITLE
Ensure "extra" arguments are always coppied

### DIFF
--- a/runperf/machine.py
+++ b/runperf/machine.py
@@ -462,7 +462,7 @@ class Controller:
         """
         test = test_class(self.main_host, workers,
                           os.path.join(self._output_dir, self.profile),
-                          self.metadata, extra)
+                          self.metadata, extra.copy())
         name = test.name
         self.log.info(f"  RUN test {name}")
         try:

--- a/runperf/tests.py
+++ b/runperf/tests.py
@@ -148,8 +148,6 @@ class PBenchTest(BaseTest):
             self.pbench_publish = True
         else:
             self.pbench_publish = False
-        # Copy the extra dict to preserve it for the following profiles
-        extra = extra.copy()
         pbench_tools = extra.pop("pbench_tools", None)
         if not pbench_tools:
             pbench_tools = metadata.get("pbench_tools", None)

--- a/selftests/core/test_tests.py
+++ b/selftests/core/test_tests.py
@@ -123,8 +123,6 @@ class PBenchTest(Selftest):
         extra["pbench_tools"] = ["extra", "set"]
         tst = self.check(tests.PBenchFio, metadata, extra, cmdline)
         self.assertEqual(tst.pbench_tools, ["extra", "set"])
-        # Check the extra is not modified by the test initialization
-        self.assertEqual({"pbench_tools": ["extra", "set"]}, extra)
 
     def test_uperf(self):
         self.check(tests.UPerf, {}, {}, 'PERL5LIB=/opt/pbench-agent/tool-'


### PR DESCRIPTION
To prevent tests tinkering with the global test's extra variables let's
always supply a copy of that dictionary. With this change we don't need
to copy the extra variable in the PbenchTest.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>