### PR TITLE
Add way to keep profile assets

### DIFF
--- a/docs/source/scripts.rst
+++ b/docs/source/scripts.rst
@@ -94,6 +94,11 @@ results in running ``Test1`` and ``Test2`` on profile ``First`` and
 ``Extra1``, ``Test1``, ``Test2`` and ``Extra2`` only on profile ``Second``
 using ``key: value`` arguments to the test ``Extra2``.
 
+To speedup setup for repeated runs you might want to try the
+``__KEEP_ASSETS__`` argument, which preserves the created assets (eg.
+images, downloaded isos, ...). Note it will not keep the images
+used in testing, just the pristine images to-be-copied for testing.
+
 Localhost
 ---------
 

--- a/runperf/profiles.py
+++ b/runperf/profiles.py
@@ -37,6 +37,13 @@ class BaseProfile:
 
     def __init__(self, host, rp_paths, extra):
         """
+        Base profile that defines basic handling
+
+        Supported extra params:
+         * __NAME__: Set the name of this profile
+         * __KEEP_ASSETS__: Keep files that would be otherwise removed by
+           the ``_path_to_be_removed`` feature (eg. pristine imgs)
+
         :param host: Host machine to apply profile on
         :param rp_paths: list of runperf paths
         """
@@ -49,6 +56,10 @@ class BaseProfile:
         name = extra.get("__NAME__")
         if name:
             self.name = utils.string_to_safe_path(name)
+        if utils.human_to_bool(extra.get("__KEEP_ASSETS__", "no")):
+            self._path_to_be_removed = lambda _: True
+        else:
+            self._path_to_be_removed = self.__path_to_be_removed
         # List of available workers
         self.workers = []
         self.log_fetcher = utils.LogFetcher()
@@ -125,7 +136,7 @@ class BaseProfile:
         """
         self.session.cmd(f"rm -rf {CONFIG_DIR + key}")
 
-    def _path_to_be_removed(self, path):
+    def __path_to_be_removed(self, path):
         """
         Register path to be removed after everything
         """

--- a/runperf/utils/__init__.py
+++ b/runperf/utils/__init__.py
@@ -410,6 +410,11 @@ def string_to_safe_path(input_str):
     return input_str.translate(_FS_TRANSLATE).replace(chr(65533), '_')
 
 
+def human_to_bool(value):
+    """Accepts multiple human values and turns it into a boolean"""
+    return str(value).strip().lower() in ("yes", "true", "t", "1")
+
+
 def ssh_copy_id(log, addr, passwords, hop=None):
     """
     Use "ssh-copy-id" to copy ssh id, try passwords if asked for.

--- a/selftests/utils/test_utils.py
+++ b/selftests/utils/test_utils.py
@@ -163,6 +163,16 @@ class BasicUtils(unittest.TestCase):
                         entries):
             self.assertRaises(KeyError, utils.named_entry_point, "", "missing")
 
+    def test_human_to_bool(self):
+        self.assertTrue(utils.human_to_bool("Yes"))
+        self.assertTrue(utils.human_to_bool("true     \n"))
+        self.assertTrue(utils.human_to_bool("T"))
+        self.assertTrue(utils.human_to_bool(1))
+        self.assertFalse(utils.human_to_bool("nop"))
+        self.assertFalse(utils.human_to_bool("no"))
+        self.assertFalse(utils.human_to_bool("not yes"))
+        self.assertFalse(utils.human_to_bool("yes\nno"))
+
 
 class Machine:
     def __init__(self, name, sessions=None):


### PR DESCRIPTION
sometimes, eg. when we invoke the same profiles multiple times like in
bisection, we might want to keep profile assets even after execution,
let's add a profile parameter to do just that.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>