### PR TITLE
Rework logging to add log files support

### DIFF
--- a/runperf/utils/__init__.py
+++ b/runperf/utils/__init__.py
@@ -40,9 +40,6 @@ FS_UNSAFE_CHARS = '<>:"/\\|?*;'
 # Translate table to replace fs-unfriendly chars
 _FS_TRANSLATE = bytes.maketrans(bytes(FS_UNSAFE_CHARS, "ascii"), b'__________')
 
-# Default log level for the MutableShellSession object
-DEFAULT_ROOT_LOG_LEVEL = logging.DEBUG
-
 CONTEXT = None
 
 
@@ -98,7 +95,7 @@ class MutableShellSession(aexpect.ShellSession):  # lgtm [py/missing-call-to-ini
                     logger.setLevel(logging.INFO)
                     return cmd(*args, **kwargs)
                 finally:
-                    logger.setLevel(DEFAULT_ROOT_LOG_LEVEL)
+                    logger.setLevel(logging.DEBUG)
                     self.set_output_func(self.__output_func)
             return cmd(*args, **kwargs)
 


### PR DESCRIPTION
Add a simple log-file support. Always use debug log level and inherit
the same output format. As we are now creating different handlers the
aexpect mute function can be simplified to only disable/enable debug
log.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>