### PR TITLE
Use multiple good/bad results in bisection

### DIFF
--- a/contrib/bisect.sh
+++ b/contrib/bisect.sh
@@ -118,6 +118,11 @@ case $1 in
         if [ "$good_or_bad" ]; then
             # Good or bad -> just move the result
             mv "${DIFFDIR}/current-result" "${DIFFDIR}/$good_or_bad";
+            if [ "$TWO_OUT_OF_THREE" == "true" ]; then
+                # Create a second good/bad result
+                execute_runperf
+                mv "${DIFFDIR}/current-result" "${DIFFDIR}/${good_or_bad}2";
+            fi
         else
             # Check -> move the current result to idx postfixed by g or b
             execute_diffperf

--- a/contrib/bisect.sh
+++ b/contrib/bisect.sh
@@ -42,7 +42,12 @@ function execute_runperf {
 
 function execute_diffperf {
     # Compare the current-result with good and bad ones
-    ${DIFFPERF} -- "${DIFFDIR}/current-result" "${DIFFDIR}/good" "${DIFFDIR}/bad"
+    declare -a goods bads
+    goods=("$DIFFDIR"/good*)
+    stat -t "${DIFFDIR}"/[0-9]*g &>/dev/null && goods+=("${DIFFDIR}"/[0-9]*g)
+    bads=("$DIFFDIR"/bad*)
+    stat -t "${DIFFDIR}"/[0-9]*b &>/dev/null && bads+=("${DIFFDIR}"/[0-9]*b)
+    ${DIFFPERF} "${DIFFDIR}/current-result" -g "${goods[@]}" -g "${bads[@]}"
     return $?
 }
 


### PR DESCRIPTION
The diff-perf tool now supports groups of results (to average the probability of all results in the group), let's use it in the bisection script to improve the accuracy of the bisection.