### PR TITLE
Log worker and controller times before test start

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -19,6 +19,8 @@ plugins:
     enabled: true
   radon:
     enabled: true
+    config:
+      threshold: "C"
   sonar-python:
     enabled: true
     config:


### PR DESCRIPTION
To simplify time-skew issues detection let's log the controller time
along with the worker time in our test-starting kmsg log. Note some
tests (pbench-fio) uses per-client time to ensure it's using only that
part of the execution which was common for all clients.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>