### PR TITLE
Disable portante copr by default

### DIFF
--- a/runperf/utils/pbench.py
+++ b/runperf/utils/pbench.py
@@ -32,7 +32,7 @@ class Dnf:  # pylint: disable=R0903
         self.extra = collections.defaultdict(lambda: '', extra)
         self.test = test
         if 'pbench_copr_repos' not in extra:
-            self.extra['pbench_copr_repos'] = 'portante/pbench;ndokos/pbench'
+            self.extra['pbench_copr_repos'] = 'ndokos/pbench'
 
     def install(self):
         """


### PR DESCRIPTION
The ndokos/pbench copr repo is the recommended one by the release notes,
the portante/pbench one should not be needed. Still people can enable it
(or any other like portante/pbench-test) by --metadata
pbench_copr_repos=XXX.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>