### PR TITLE
Use at least 180s timeout for the pbench watchdog

### DIFF
--- a/runperf/tests.py
+++ b/runperf/tests.py
@@ -180,9 +180,9 @@ class PBenchTest(BaseTest):
             if key.startswith("__"):
                 continue
             if key == "runtime":
-                # Allow 2-times runtime output stalls, min 60s to avoid failing
+                # Allow 2-times runtime output stalls, or 180s to avoid failing
                 # on sysinfo collection
-                self.watchdog_timeout = max(60, int(value) * 2)
+                self.watchdog_timeout = max(180, int(value) * 2)
             # __PER_WORKER_CPUS__ == no cpus perf worker
             if value == "__PER_WORKER_CPUS__":
                 for _workers in self.workers:


### PR DESCRIPTION
the 60s interval is not enough for the sysinfo collection for the longer running tasks.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>