### PR TITLE
Set selinux label for the qemu bioses

### DIFF
--- a/contrib/upstream_qemu_bisect.sh
+++ b/contrib/upstream_qemu_bisect.sh
@@ -103,6 +103,7 @@ VERSION=$(git rev-parse HEAD)
 make -j $(getconf _NPROCESSORS_ONLN) || { echo "Qemu make FAILed"; exit -1; }
 make install || { echo "Qemu make install FAILed"; exit -1; }
 chcon -Rt qemu_exec_t /usr/local/bin/qemu-system-"$(uname -m)"
+chcon -Rt virt_image_t /usr/local/share/qemu/
 cp -f build/config.status /usr/local/share/qemu/
 popd
 INNEREOF

--- a/docs/source/jenkins/runperf.groovy
+++ b/docs/source/jenkins/runperf.groovy
@@ -115,6 +115,7 @@ node(workerNode) {
             hostScript += '--with-pkgversion="$VERSION"'
             hostScript += runperf.makeInstallCmd
             hostScript += '\nchcon -Rt qemu_exec_t /usr/local/bin/qemu-system-"$(uname -m)"'
+            hostScript += '\nchcon -Rt virt_image_t /usr/local/share/qemu/'
             hostScript += '\n\\cp -f build/config.status /usr/local/share/qemu/'
             hostScript += '\ncd $OLD_PWD'
         }


### PR DESCRIPTION
otherwise they can not be used when selinux is enabled on the system.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>