### PR TITLE
Log the pbench command when runnnig with a watchdog

### DIFF
--- a/runperf/tests.py
+++ b/runperf/tests.py
@@ -323,7 +323,9 @@ class PBenchTest(BaseTest):
                 session.cmd(". /opt/pbench-agent/base")
                 if self.watchdog_timeout:
                     # Run the test while checking the output for stalls
-                    self._run_with_watchdog(prefix + self._cmd, session,
+                    cmd = prefix + self._cmd
+                    self.host.log.debug("Sending command: %s", cmd)
+                    self._run_with_watchdog(cmd, session,
                                             self.timeout,
                                             self.watchdog_timeout)
                 else:


### PR DESCRIPTION
we get that by default in the non-watchdog branch, but watchdog version uses "sendline" that is currently not printing any output. Add it so we get all commands logged.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>