### PR TITLE
Require RPM version of the test pkg in DNF provider

### DIFF
--- a/runperf/utils/pbench.py
+++ b/runperf/utils/pbench.py
@@ -94,8 +94,6 @@ class Dnf:  # pylint: disable=R0903
 
     def _check_test_installed(self):
         """Report whether test pkg is installed"""
-        if not self.session.cmd_status(f"which {self.test}"):
-            return True
         if not self.session.cmd_status(f"rpm -q {self.test}"):
             return True
         if not self.session.cmd_status(f"rpm -q pbench-{self.test}"):


### PR DESCRIPTION
Pbench requires the RPM version to be available even though it might not be actually used. Let's require it in our DNF version as well.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>