### PR TITLE
Allow collecting user sysinfo

### DIFF
--- a/docs/source/scripts.rst
+++ b/docs/source/scripts.rst
@@ -319,6 +319,7 @@ build metadata file. Before the execution it gathers:
   * ``kernel`` - kernel cmdline
   * ``mitigations`` - mitigations reported by kernel
   * ``rpm`` - ``rpm -qa`` (if available)
+  * ``systemctl`` - list of services with some dynamic services excluded
   * ``runperf_sysinfo`` - content of ``/var/lib/runperf/sysinfo`` file (free-form
                       user keys, sorted by line to allow diffing)
   * ``params`` - machine params (coming from runperf params)

--- a/docs/source/scripts.rst
+++ b/docs/source/scripts.rst
@@ -313,11 +313,16 @@ build metadata file. Before the execution it gathers:
   to the first target machine is stored here. It's used by the html
   plugin to add a link to the target machine (eg. beaker where one can
   see the hw info)
+* ``environment_*`` - system(s) environment per each profile.
 
-Additionally on profile revert a profile environment is being collected and
-in the end all target system environment is also gathered and injected
-into the metadata json file. These can be used to compare the environments
-in case of a change.
+  * ``general`` - hostname and distro name
+  * ``kernel`` - kernel cmdline
+  * ``mitigations`` - mitigations reported by kernel
+  * ``rpm`` - ``rpm -qa`` (if available)
+  * ``runperf_sysinfo`` - content of ``/var/lib/runperf/sysinfo`` file (free-form
+                      user keys, sorted by line to allow diffing)
+  * ``params`` - machine params (coming from runperf params)
+
 
 .. note:: For test environment changes run-perf relies on pbench result
    file format where benchmark params are stored under

--- a/runperf/machine.py
+++ b/runperf/machine.py
@@ -63,6 +63,11 @@ def get_distro_info(machine):
         if session.cmd_status("which rpm", print_func='mute') == 0:
             out["rpm"] = session.cmd("rpm -qa | sort", print_func='mute',
                                      ignore_all_errors=True)
+        out["systemctl"] = session.cmd("systemctl | "
+                                       "grep -v 'session-[0-9]*\\.scope'"
+                                       " | tr -s ' ' | uniq | sort",
+                                       print_func='mute',
+                                       ignore_all_errors=True)
         out["runperf_sysinfo"] = session.cmd("cat /var/lib/runperf/sysinfo "
                                              "| uniq | sort",
                                              print_func='mute',

--- a/runperf/machine.py
+++ b/runperf/machine.py
@@ -63,6 +63,10 @@ def get_distro_info(machine):
         if session.cmd_status("which rpm", print_func='mute') == 0:
             out["rpm"] = session.cmd("rpm -qa | sort", print_func='mute',
                                      ignore_all_errors=True)
+        out["runperf_sysinfo"] = session.cmd("cat /var/lib/runperf/sysinfo "
+                                             "| uniq | sort",
+                                             print_func='mute',
+                                             ignore_all_errors=True)
     return out
 
 

--- a/runperf/tests.py
+++ b/runperf/tests.py
@@ -110,9 +110,9 @@ class BaseTest:
         if session.cmd_status(f"[ -d '{dir_path}' ]") == 0:
             result_path = os.path.join(dir_path, "RUNPERF_METADATA.json")
             results_json = json.dumps(meta, indent=4, sort_keys=True)
-            session.cmd(utils.shell_write_content_cmd(result_path,
-                                                      results_json),
-                        timeout=600, print_func='mute')
+            utils.shell_write_content(
+                lambda cmd: session.cmd(cmd, timeout=600, print_func='mute'),
+                result_path, results_json)
 
     def cleanup(self):
         """

--- a/selftests/core/test_machine.py
+++ b/selftests/core/test_machine.py
@@ -172,40 +172,46 @@ class GetDistroInfo(Selftest):
                              "resume=/dev/mapper/fedora-swap ro "
                              "root=/dev/mapper/fedora-root",
                'mitigations': VULNERABILITIES,
-               'rpm': 'mc-4.8.24-4.fc32.x86_64\n'}
+               'rpm': 'mc-4.8.24-4.fc32.x86_64\n',
+               'runperf_sysinfo': ''}
         kernel, cmdline = exp['kernel_raw'].rsplit('\n', 1)
-        cmd = [kernel, cmdline, exp['mitigations'], exp['rpm']]
+        cmd = [kernel, cmdline, exp['mitigations'], exp['rpm'],
+               exp['runperf_sysinfo']]
         cmd_status = 0
         self.check(cmd, cmd_status, exp)
 
     def test_order(self):
         # Check ordering works well including filtering
-        self.check(["1.2.3", "c a=1.2.3 b", ""], 1,
+        self.check(["1.2.3", "c a=1.2.3 b", "", "", ""], 1,
                    {'general': 'Name:My Machine\nDistro:My Distro',
                     'kernel': '1.2.3\na=FILTERED b c',
                     'kernel_raw': '1.2.3\nc a=1.2.3 b',
-                    'mitigations': ''})
+                    'mitigations': '',
+                    'runperf_sysinfo': ''})
         # kernel must be equal for the following 2 commands even though the
         # last item with \n is different
         self.check(["1.2.3\nuname -v\nuname -m\n", "a=b c=d\n",
-                    ""], 1,
+                    "", "", ""], 1,
                    {'general': 'Name:My Machine\nDistro:My Distro',
                     'kernel': '1.2.3\nuname -v\nuname -m\n\na=b c=d',
                     'kernel_raw': '1.2.3\nuname -v\nuname -m\n\na=b c=d\n',
-                    'mitigations': ''})
+                    'mitigations': '',
+                    'runperf_sysinfo': ''})
         self.check(["1.2.3\nuname -v\nuname -m\n", "c=d a=b\n",
-                    ""], 1,
+                    "", "", ""], 1,
                    {'general': 'Name:My Machine\nDistro:My Distro',
                     'kernel': '1.2.3\nuname -v\nuname -m\n\na=b c=d',
                     'kernel_raw': '1.2.3\nuname -v\nuname -m\n\nc=d a=b\n',
-                    'mitigations': ''})
+                    'mitigations': '',
+                    'runperf_sysinfo': ''})
 
     def test_no_output(self):
-        self.check(["", "", ""], 1,
+        self.check(["", "", "", "", ""], 1,
                    {'general': 'Name:My Machine\nDistro:My Distro',
                     'kernel': '\nFILTERED',
                     'kernel_raw': '\n',
-                    'mitigations': ''})
+                    'mitigations': '',
+                    'runperf_sysinfo': ''})
 
 
 class ControllerTests(Selftest):

--- a/selftests/core/test_machine.py
+++ b/selftests/core/test_machine.py
@@ -173,10 +173,13 @@ class GetDistroInfo(Selftest):
                              "root=/dev/mapper/fedora-root",
                'mitigations': VULNERABILITIES,
                'rpm': 'mc-4.8.24-4.fc32.x86_64\n',
+               'systemctl': 'abrtd.service loaded active running ABRT '
+               'Automated Bug Reporting Tool\n...\nvirtlogd.socket loaded '
+               'active listening Virtual machine log manager socket\n',
                'runperf_sysinfo': ''}
         kernel, cmdline = exp['kernel_raw'].rsplit('\n', 1)
         cmd = [kernel, cmdline, exp['mitigations'], exp['rpm'],
-               exp['runperf_sysinfo']]
+               exp['systemctl'], exp['runperf_sysinfo']]
         cmd_status = 0
         self.check(cmd, cmd_status, exp)
 
@@ -187,6 +190,7 @@ class GetDistroInfo(Selftest):
                     'kernel': '1.2.3\na=FILTERED b c',
                     'kernel_raw': '1.2.3\nc a=1.2.3 b',
                     'mitigations': '',
+                    'systemctl': '',
                     'runperf_sysinfo': ''})
         # kernel must be equal for the following 2 commands even though the
         # last item with \n is different
@@ -196,6 +200,7 @@ class GetDistroInfo(Selftest):
                     'kernel': '1.2.3\nuname -v\nuname -m\n\na=b c=d',
                     'kernel_raw': '1.2.3\nuname -v\nuname -m\n\na=b c=d\n',
                     'mitigations': '',
+                    'systemctl': '',
                     'runperf_sysinfo': ''})
         self.check(["1.2.3\nuname -v\nuname -m\n", "c=d a=b\n",
                     "", "", ""], 1,
@@ -203,6 +208,7 @@ class GetDistroInfo(Selftest):
                     'kernel': '1.2.3\nuname -v\nuname -m\n\na=b c=d',
                     'kernel_raw': '1.2.3\nuname -v\nuname -m\n\nc=d a=b\n',
                     'mitigations': '',
+                    'systemctl': '',
                     'runperf_sysinfo': ''})
 
     def test_no_output(self):
@@ -211,6 +217,7 @@ class GetDistroInfo(Selftest):
                     'kernel': '\nFILTERED',
                     'kernel_raw': '\n',
                     'mitigations': '',
+                    'systemctl': '',
                     'runperf_sysinfo': ''})
 
 

--- a/selftests/core/test_profiles.py
+++ b/selftests/core/test_profiles.py
@@ -108,7 +108,8 @@ class ProfileUnitTests(Selftest):
             if "rpm" in info:  # rpm is only there when rpm command available
                 info.remove("rpm")
             self.assertEqual(["general", "kernel_raw", "kernel",
-                              "mitigations", "params"], info)
+                              "mitigations", "runperf_sysinfo",
+                              "params"], info)
             # revert not applied profile
             profile.revert()
             # revert different profile
@@ -252,9 +253,11 @@ class RunPerfTest(Selftest):
                 info.remove("rpm")
                 info.remove("guest0_rpm")
             self.assertEqual(['general', 'kernel_raw', 'kernel',
-                              'mitigations', 'params', 'persistent',
+                              'mitigations', 'runperf_sysinfo',
+                              'params', 'persistent',
                               'guest0_general', 'guest0_kernel_raw',
                               'guest0_kernel', 'guest0_mitigations',
+                              'guest0_runperf_sysinfo',
                               'guest0_params'], info)
             # Revert the profile
             session.cmd_status.side_effect = (0, 1, 0, 0, 0, 0)

--- a/selftests/core/test_profiles.py
+++ b/selftests/core/test_profiles.py
@@ -108,7 +108,7 @@ class ProfileUnitTests(Selftest):
             if "rpm" in info:  # rpm is only there when rpm command available
                 info.remove("rpm")
             self.assertEqual(["general", "kernel_raw", "kernel",
-                              "mitigations", "runperf_sysinfo",
+                              "mitigations", "systemctl", "runperf_sysinfo",
                               "params"], info)
             # revert not applied profile
             profile.revert()
@@ -253,11 +253,11 @@ class RunPerfTest(Selftest):
                 info.remove("rpm")
                 info.remove("guest0_rpm")
             self.assertEqual(['general', 'kernel_raw', 'kernel',
-                              'mitigations', 'runperf_sysinfo',
+                              'mitigations', 'systemctl', 'runperf_sysinfo',
                               'params', 'persistent',
                               'guest0_general', 'guest0_kernel_raw',
                               'guest0_kernel', 'guest0_mitigations',
-                              'guest0_runperf_sysinfo',
+                              'guest0_systemctl', 'guest0_runperf_sysinfo',
                               'guest0_params'], info)
             # Revert the profile
             session.cmd_status.side_effect = (0, 1, 0, 0, 0, 0)

--- a/selftests/utils/test_utils.py
+++ b/selftests/utils/test_utils.py
@@ -369,15 +369,12 @@ class Pbench(unittest.TestCase):
         session = mock.Mock()
         pbench = utils.pbench.Dnf(session, {}, "test")
         session.cmd_status.side_effect = [0]
-        self.assertTrue(pbench._check_test_installed(), "which should report "
+        self.assertTrue(pbench._check_test_installed(), "rpm should report "
                         f"installed\n{session.mock_calls}")
         session.cmd_status.side_effect = [1, 0]
         self.assertTrue(pbench._check_test_installed(), "rpm should report "
-                        f"installed\n{session.mock_calls}")
-        session.cmd_status.side_effect = [1, 1, 0]
-        self.assertTrue(pbench._check_test_installed(), "rpm should report "
                         f"pbench-$name installed\n{session.mock_calls}")
-        session.cmd_status.side_effect = [1, 1, 1]
+        session.cmd_status.side_effect = [1, 1]
         self.assertFalse(pbench._check_test_installed(), "Should not report "
                          f"installed\n{session.mock_calls}")
 


### PR DESCRIPTION
For self-compiled tools we might want to add custom entries to our environment sysinfo to know when something changes. Also add services statuses.