### PR TITLE
docs.jenkins: Fix var name in multi_runperf

### DIFF
--- a/docs/source/jenkins/multi_runperf.groovy
+++ b/docs/source/jenkins/multi_runperf.groovy
@@ -46,11 +46,11 @@ guestDistrosRaw = params.GUEST_DISTROS.split(csvSeparator)
 // Add custom kernel arguments on host
 hostKernelArgss = params.HOST_KERNEL_ARGSS.split(csvSeparator)
 // Install rpms from (beaker) urls
-hostRpmFromURLss = params.HOST_RPM_FROM_URLS.trim().split(doubleEnter)
+hostRpmFromURLss = params.HOST_RPM_FROM_URLSS.trim().split(doubleEnter)
 // Add custom kernel argsuments on workers/guests
 guestKernelArgss = params.GUEST_KERNEL_ARGSS.split(csvSeparator)
 // Install rpms from (beaker) urls
-guestRpmFromURLss = params.GUEST_RPM_FROM_URLS.trim().split(doubleEnter)
+guestRpmFromURLss = params.GUEST_RPM_FROM_URLSS.trim().split(doubleEnter)
 // Add steps to checkout, compile and install the upstream qemu from git
 upstreamQemuCommits = params.UPSTREAM_QEMU_COMMITS.split(csvSeparator)
 // Custom host/guest setups cript


### PR DESCRIPTION
When changing the rpm pkgs deployment we missed the 'S' in the multi_runperf pipeline.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>