### PR TITLE
Be more agressive when rebooting the system

### DIFF
--- a/runperf/machine.py
+++ b/runperf/machine.py
@@ -614,8 +614,8 @@ class Host(BaseMachine):
         """Gracefully reboot the machine"""
         self.log.debug("  Rebooting...")
         with self.get_session_cont() as session:
-            session.sendline("reboot")
-        time.sleep(10)
+            session.sendline("reboot -f")
+        time.sleep(30)
         with self.get_session_cont(360):
             # Just checking whether it's obtainable
             pass

--- a/runperf/provisioners.py
+++ b/runperf/provisioners.py
@@ -48,7 +48,7 @@ class Beaker:
         # Wait for 3 minutes to let beaker to restart the machine
         time.sleep(180)
 
-        with machine.get_session_cont(2400) as session:
+        with machine.get_session_cont(3000) as session:
             if not utils.wait_for_machine_calms_down(session, 1800):
                 machine.log.warning("Machine did not stabilize in 1800s, "
                                     "proceeding on a loaded machine!")


### PR DESCRIPTION
Some machines are just not giving up and even after 10s are still reachable via ssh. Let's prolong the timeout and use '-f' to forcefully reboot the machine (first "reboot -f" is still clean).