### PR TITLE
Keep the session open on reboot

### DIFF
--- a/runperf/machine.py
+++ b/runperf/machine.py
@@ -615,7 +615,7 @@ class Host(BaseMachine):
         self.log.debug("  Rebooting...")
         with self.get_session_cont() as session:
             session.sendline("reboot -f")
-        time.sleep(30)
+            time.sleep(30)
         with self.get_session_cont(360):
             # Just checking whether it's obtainable
             pass


### PR DESCRIPTION
the core issue of non-rebooting seems not waiting enough for session.sendline to actually send the command. Avoid that by waiting with the session open.