### PR TITLE
Revert d2d21a949584c892387225603f959d5b655df574

### DIFF
--- a/runperf/machine.py
+++ b/runperf/machine.py
@@ -614,7 +614,7 @@ class Host(BaseMachine):
         """Gracefully reboot the machine"""
         self.log.debug("  Rebooting...")
         with self.get_session_cont() as session:
-            session.sendline("reboot -f")
+            session.sendline("reboot")
             time.sleep(30)
         with self.get_session_cont(360):
             # Just checking whether it's obtainable


### PR DESCRIPTION
the "reboot -f" sometimes caused the grubby args not to be applied, let's keep the old "reboot" only while using the fix from b8607d155eb0d8aa92cc33469482fd7dffae49d8