### PR TITLE
pbench: Add pbench-agent repo

### DIFF
--- a/runperf/utils/pbench.py
+++ b/runperf/utils/pbench.py
@@ -32,7 +32,7 @@ class Dnf:  # pylint: disable=R0903
         self.extra = collections.defaultdict(lambda: '', extra)
         self.test = test
         if 'pbench_copr_repos' not in extra:
-            self.extra['pbench_copr_repos'] = 'ndokos/pbench'
+            self.extra['pbench_copr_repos'] = 'ndokos/pbench;ndokos/pbench-0.73'
 
     def install(self):
         """

--- a/selftests/utils/test_utils.py
+++ b/selftests/utils/test_utils.py
@@ -339,7 +339,7 @@ class Pbench(unittest.TestCase):
                 count += 1
                 self.assertIn("copr enable ndokos/pbench", call, "Enabling "
                               f"copr that is not ndokos/pbench\n{calls}")
-        self.assertEqual(count, 1, f"Multiple copr enable calls\n{calls}")
+        self.assertEqual(count, 2, f"Multiple copr enable calls\n{calls}")
 
     def test_install_fedora_coprs(self):
         """Pretend to be Fedora and verify custom coprs"""


### PR DESCRIPTION
the newer pbench-agent rpms are shipped in versioned repos, add the current latest pbench-0.73 by default (while allowing to modify it via metadata.